### PR TITLE
Log dataset revisions and make them downloadable.

### DIFF
--- a/html/revisions.html
+++ b/html/revisions.html
@@ -1,0 +1,58 @@
+<!DOCTYPE html>
+<!--
+Copyright 2020 Open Reaction Database Project Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-->
+<html>
+  <head>
+    <title>{{ name }} Revisions</title>
+    <script>
+      const tz = location.href.match(/\?tz=([0-9])+/)
+      if (!tz) {
+        const hours = (new Date()).getTimezoneOffset() / 60;
+        location.replace(location + '?tz=' + hours);
+      }
+    </script>
+  </head>
+  <style>
+    html, body {
+      margin: 0;
+      font-family: Roboto;
+    }
+    body {
+      padding: 48px;
+    }
+    td {
+      padding: 8px;
+    }
+    #identity {
+      float: right;
+    }
+  </style>
+  <body>
+    <div id="identity">{{ user_id }} <a href="/logout">logout</a></div>
+    <center>
+      <h1>Revisions of <a href="/dataset/{{ name }}">{{ name }}.pbtxt</a></h1>
+      {% if not revisions %}
+        This dataset has no revisions.
+      {% endif %}
+      <table>
+        {% for localtime, timestamp in revisions %}
+          <tr><td><a href="/revision/{{ name }}/{{ timestamp }}">{{ localtime }}</a></td></tr>
+        {% endfor %}
+      </table>
+    </center>
+  </body>
+</html>
+

--- a/js/reaction.js
+++ b/js/reaction.js
@@ -364,7 +364,7 @@ function checkpoint() {
   const reaction = unloadReaction();
   const reactions = session.dataset.getReactionsList();
   reactions[session.index] = reaction;
-  putRevision(session.fileName, session.dataset)
+  putRevision(session.fileName, session.dataset);
 }
 
 /**

--- a/py/serve.py
+++ b/py/serve.py
@@ -15,6 +15,7 @@
 
 import collections
 import contextlib
+import datetime
 import fcntl
 import io
 import json
@@ -555,6 +556,68 @@ def sync_reviews():
                 cursor.execute(query, [user_id, name, pbtxt])
     flask.g.db.commit()
     return flask.redirect('/review')
+
+
+@app.route('/revisions/<name>')
+def show_revisions(name):
+    """List all historical revisions of a dataset for download."""
+    # Offset relative to UTC, for localized timestamp representation.
+    hours = 0
+    if 'tz' in flask.request.args:
+        hours = int(flask.request.args.get('tz'))
+    revisions = []
+    with flask.g.db.cursor() as cursor:
+        query = psycopg2.sql.SQL('SELECT timestamp FROM revisions '
+                                 'WHERE user_id=%s and dataset_name=%s '
+                                 'ORDER BY timestamp DESC')
+        user_id = flask.g.user_id
+        cursor.execute(query, [user_id, name])
+        for row in cursor:
+            timestamp = int(row[0])
+            localtime = (
+                datetime.datetime.utcfromtimestamp(timestamp) -
+                datetime.timedelta(hours=hours)).strftime('%Y-%m-%d %H:%M:%S')
+            revisions.append((localtime, timestamp))
+    return flask.render_template('revisions.html',
+                                 name=name,
+                                 revisions=revisions,
+                                 user_id=user_id)
+
+
+@app.route('/checkpoint/<name>', methods=['POST'])
+def checkpoint(name):
+    """Append a dataset to the "revisions" list."""
+    dataset = dataset_pb2.Dataset()
+    dataset.ParseFromString(flask.request.get_data())
+    resolve_tokens(dataset)
+    with flask.g.db.cursor() as cursor:
+        query = psycopg2.sql.SQL(
+            'INSERT INTO revisions VALUES (%s, %s, %s, %s)')
+        timestamp = int(time.time())
+        user_id = flask.g.user_id
+        pbtxt = text_format.MessageToString(dataset, as_utf8=True)
+        cursor.execute(query, [user_id, name, pbtxt, timestamp])
+        flask.g.db.commit()
+    return 'ok'
+
+
+@app.route('/revision/<name>/<timestamp>')
+def download_revision(name, timestamp):
+    """Read back a dataset checkpoint identified by its name and timestamp."""
+    with flask.g.db.cursor() as cursor:
+        query = psycopg2.sql.SQL(
+            'SELECT pbtxt FROM revisions '
+            'WHERE user_id=%s AND dataset_name=%s AND timestamp=%s')
+        user_id = flask.g.user_id
+        cursor.execute(query, [user_id, name, int(timestamp)])
+        if cursor.rowcount == 0:
+            flask.abort(404)
+        pbtxt = cursor.fetchone()[0]
+    data = io.BytesIO(pbtxt.encode('utf8'))
+    return flask.send_file(data,
+                           mimetype='application/protobuf',
+                           as_attachment=True,
+                           attachment_filename=f'{name}-{timestamp}.pbtxt')
 
 
 @app.after_request

--- a/schema.sql
+++ b/schema.sql
@@ -47,6 +47,15 @@ CREATE TABLE datasets (
   PRIMARY KEY (user_id, dataset_name)
 );
 
+CREATE TABLE revisions (
+  user_id CHARACTER(32) REFERENCES users,
+  dataset_name TEXT NOT NULL,
+  pbtxt TEXT NOT NULL,
+  timestamp INTEGER NOT NULL,
+  FOREIGN KEY (user_id, dataset_name)
+      REFERENCES datasets (user_id, dataset_name)
+);
+
 -- System users:
 --   "review" owns read-only datasets imported from GitHub pull requests.
 --   "test" owns datasets imported from db/ and used only in tests.


### PR DESCRIPTION
Make it possible to recover from unintended deletions. This is currently running on the staging instance at http://34.123.154.187/.

- A new table, "revisions" logs datasets with timestamps.

- A new JS behavior logs a checkpoint before taking action on any "remove" button.

- A new endpoint, "/checkpoint" appends to the revisions log.

- A new web page, "/revisions" shows this log for a given dataset, each with a timestamp linking to the historical pbtxt.

It's not exactly an undo feature, but it makes recovery possible from some kinds of mistake. The procedure after a loss is: go to /revisions; pick your log entry; download it; and upload it again.

This could be integrated into the editor with little effort by adding an editor affordance showing the revision list and linking from there to a Flask function that reverts the dataset and reloads the page.