### PR TITLE
Version ord-schema in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -61,8 +61,8 @@ WORKDIR ..
 RUN git clone https://github.com/Open-Reaction-Database/ord-schema.git
 WORKDIR ord-schema
 # NOTE(kearnes): ord-schema is versioned to avoid breaking ord-editor.
-ARG ORD_SCHEMA_SHA=79d330952a1d82c5061f37c2d3d5859213507487
-RUN git checkout ${ORD_SCHEMA_SHA}
+ARG ORD_SCHEMA_TAG=v0.1.0
+RUN git fetch --tags && git checkout ${ORD_SCHEMA_TAG}
 RUN pip install -r requirements.txt
 RUN python setup.py install
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -58,10 +58,11 @@ RUN wget https://github.com/protocolbuffers/protobuf/releases/download/v3.13.0/p
 
 # Install ord-schema.
 WORKDIR ..
-# Bust the cache to get the latest commits; see https://stackoverflow.com/a/39278224.
-ADD "https://api.github.com/repos/Open-Reaction-Database/ord-schema/git/refs/heads/main" ord-schema-version.json
 RUN git clone https://github.com/Open-Reaction-Database/ord-schema.git
 WORKDIR ord-schema
+# NOTE(kearnes): ord-schema is versioned to avoid breaking ord-editor.
+ARG ORD_SCHEMA_SHA=79d330952a1d82c5061f37c2d3d5859213507487
+RUN git checkout ${ORD_SCHEMA_SHA}
 RUN pip install -r requirements.txt
 RUN python setup.py install
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -62,7 +62,7 @@ RUN git clone https://github.com/Open-Reaction-Database/ord-schema.git
 WORKDIR ord-schema
 # NOTE(kearnes): ord-schema is versioned to avoid breaking ord-editor.
 ARG ORD_SCHEMA_TAG=v0.1.0
-RUN git fetch --tags && git checkout ${ORD_SCHEMA_TAG}
+RUN git fetch --tags && git checkout "${ORD_SCHEMA_TAG}"
 RUN pip install -r requirements.txt
 RUN python setup.py install
 


### PR DESCRIPTION
This PR uses a specific ord-schema commit hash to avoid breakage in the editor when new changes are introduced to ord-schema. This allows the editor to be brought up to date asynchronously.

Note that users who are doing local development on ord-editor without using docker will need to ensure that their copy of ord-schema also matches this SHA.