### PR TITLE
Respect legacy user IDs in URLs.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,8 @@ __pycache__
 # build output
 /build
 /dist
+# dependencies from manual builds
+closure-library-*
+gen
+ketcher
+protobuf-*

--- a/.gitignore
+++ b/.gitignore
@@ -14,8 +14,10 @@ __pycache__
 # build output
 /build
 /dist
-# dependencies from manual builds
+# dependency artifacts from manual builds
 closure-library-*
 gen
 ketcher
 protobuf-*
+node_modules
+package-lock.json

--- a/js/test.js
+++ b/js/test.js
@@ -71,7 +71,7 @@ const puppeteer = require('puppeteer');
   // Additional test to ensure that pretending to change field entries does
   // not lead to a change in the number of validation errors.
   const validationTests = [
-    'http://localhost:5000/dataset/ord-nielsen-example/reaction/0?user=test',
+    'http://localhost:5000/dataset/ord-nielsen-example/reaction/0',
   ];
 
   for (let i = 0; i < validationTests.length; i++) {

--- a/py/serve.py
+++ b/py/serve.py
@@ -768,6 +768,13 @@ def init_user():
                                   port=int(POSTGRES_PORT))
     if flask.request.path in ('/login', '/authenticate'):
         return
+    if 'ord-editor-user' in flask.request.cookies:
+        # Respect legacy user ID's in cookies.
+        user_id = flask.request.cookies.get('ord-editor-user')
+        response = issue_access_token(user_id)
+        # Delete the old cookie to avoid a redirect loop.
+        response.set_cookie('ord-editor-user', '', expires=0)
+        return response
     if 'user' in flask.request.args:
         # Respect legacy user ID's in URLs.
         user_id = flask.request.args.get('user')

--- a/py/serve.py
+++ b/py/serve.py
@@ -768,6 +768,10 @@ def init_user():
                                   port=int(POSTGRES_PORT))
     if flask.request.path in ('/login', '/authenticate'):
         return
+    if 'user' in flask.request.args:
+        # Respect legacy user ID's in URLs.
+        user_id = flask.request.args.get('user')
+        return issue_access_token(user_id);
     access_token = flask.request.cookies.get('Access-Token')
     if access_token is None:
         # Automatically login as a new user.

--- a/py/serve.py
+++ b/py/serve.py
@@ -771,7 +771,7 @@ def init_user():
     if 'user' in flask.request.args:
         # Respect legacy user ID's in URLs.
         user_id = flask.request.args.get('user')
-        return issue_access_token(user_id);
+        return issue_access_token(user_id)
     access_token = flask.request.cookies.get('Access-Token')
     if access_token is None:
         # Automatically login as a new user.


### PR DESCRIPTION
If there is a GET param "user" in the URL, then immediately issue an access token for the user ID specified in the param value. 

Bookmarks will continue to function as expected. No one will be slammed into a new user ID. If a client presents a "user" param that does not correspond to any known user, they will see an error response.

Also update the .gitignore for the several dependencies required by manual builds (non-Docker).