### PR TITLE
WIP GitHub authentication

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -40,6 +40,8 @@ services:
     environment:
       - POSTGRES_HOST=db
       - POSTGRES_PASSWORD=${ORD_EDITOR_POSTGRES_PASSWORD}
+      - GH_CLIENT_ID=${GH_CLIENT_ID}
+      - GH_CLIENT_SECRET=${GH_CLIENT_SECRET}
     image: "openreactiondatabase/ord-editor"
     ports:
       - "5000:5000"

--- a/html/login.html
+++ b/html/login.html
@@ -34,10 +34,9 @@ limitations under the License.
     }
   </style>
   <body>
-    <form action="/authenticate" method="POST">
-      <label>User ID</label>
-      <input type="text" name="user_id">
-      <input type="submit" value="Login">
+    <form action="https://github.com/login/oauth/authorize" method="GET">
+      <input type="hidden" name="client_id" value="{{ client_id }}">
+      <input type="submit" value="Sign in with GitHub">
     </form>
   </body>
 </html>

--- a/py/serve.py
+++ b/py/serve.py
@@ -735,7 +735,7 @@ def github_callback():
         'Authorization': f'token {access_token}',
     }
     # GitHub username is user['login'].
-    user = requests.get('https://api.github.com/user', headers=headers)
+    user = requests.get('https://api.github.com/user', headers=headers).json()
 
 
 @app.route('/authenticate', methods=['GET', 'POST'])


### PR DESCRIPTION
Going to `/login` and clicking "Sign in with GitHub" asks for read-only access to public GitHub account attributes (default token scope) and redirects to '/github-callback'. See the code for the workflow there, which requests an access token from GitHub.

Next steps:
* Update the postgres db with information about this user.
* Allow guest access without logging in.
* Make test and review data available to all users.

@antonkast-google FYI