### PR TITLE
Login with GitHub

### DIFF
--- a/css/reaction.css
+++ b/css/reaction.css
@@ -216,4 +216,11 @@ fieldset {
 #identity {
   float: right;
   width: 400px;
+  display: flex;
+  align-items: center;
+}
+#identity img {
+  width: 24px;
+  margin-right: 8px;
+  border-radius: 12px;
 }

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -40,6 +40,8 @@ services:
     environment:
       - POSTGRES_HOST=db
       - POSTGRES_PASSWORD=${ORD_EDITOR_POSTGRES_PASSWORD}
+      - GH_CLIENT_ID=${GH_CLIENT_ID}
+      - GH_CLIENT_SECRET=${GH_CLIENT_SECRET}
     image: "openreactiondatabase/ord-editor"
     ports:
       - "5000:5000"

--- a/html/dataset.html
+++ b/html/dataset.html
@@ -64,6 +64,13 @@ limitations under the License.
       }
       #identity {
         float: right;
+        display: flex;
+        align-items: center;
+      }
+      #identity img {
+        width: 24px;
+        margin-right: 8px;
+        border-radius: 12px;
       }
     </style>
     <script src="https://ajax.googleapis.com/ajax/libs/jquery/3.5.1/jquery.min.js"></script>
@@ -71,7 +78,7 @@ limitations under the License.
   </head>
   <body>
 
-    <div id="identity">{{ user_id }} <a href="/logout">logout</a></div>
+    <div id="identity"><img src="{{ user_avatar }}">{{ user_name }}&nbsp;<a href="/logout">logout</a></div>
 
     <center>
       <h1><a href="/">Dataset</a>: {{ name }}.pbtxt</h1>

--- a/html/datasets.html
+++ b/html/datasets.html
@@ -57,6 +57,13 @@ limitations under the License.
     }
     #identity {
       float: right;
+      display: flex;
+      align-items: center;
+    }
+    #identity img {
+      width: 24px;
+      margin-right: 8px;
+      border-radius: 12px;
     }
   </style>
   <script src="https://ajax.googleapis.com/ajax/libs/jquery/3.5.1/jquery.min.js"></script>
@@ -64,7 +71,7 @@ limitations under the License.
   <script src="https://stackpath.bootstrapcdn.com/bootstrap/4.5.0/js/bootstrap.min.js"></script>
   <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/5.13.1/css/all.min.css">
   <body>
-    <div id="identity">{{ user_id }} <a href="/logout">logout</a></div>
+    <div id="identity"><img src="{{ user_avatar }}">{{ user_name }}&nbsp;<a href="/logout">logout</a></div>
     <center>
       <h1>Available datasets</h1>
       <div id="saving" style="visibility: hidden;">saving</div>

--- a/html/login.html
+++ b/html/login.html
@@ -34,10 +34,9 @@ limitations under the License.
     }
   </style>
   <body>
-    <form action="/authenticate" method="POST">
-      <label>User ID</label>
-      <input type="text" name="user_id">
-      <input type="submit" value="Login">
+    <form action="https://github.com/login/oauth/authorize" method="GET">
+      <input type="hidden" name="client_id" value="{{ client_id }}">
+      <input type="submit" value="Sign in with GitHub">
     </form>
   </body>
 </html>

--- a/html/login.html
+++ b/html/login.html
@@ -17,26 +17,47 @@ limitations under the License.
 <html>
   <head>
     <title>Login</title>
+    <script src="https://ajax.googleapis.com/ajax/libs/jquery/3.5.1/jquery.min.js"></script>
   </head>
   <style>
-    html, body, form {
+    html, body, #container {
       height: 100%;
       margin: 0;
-      font-family: Roboto;
     }
-    form {
+    img {
+      width: 100px;
+      padding-right: 14px;
+    }
+    #container {
       display: flex;
       justify-content: center;
       align-items: center;
     }
-    input {
-      margin: 8px;
+    #button {
+      display: flex;
+      align-items: center;
+      padding: 16px;
+      font-family: Roboto;
+      font-size: 20pt;
+      border-style: solid;
+      border-color: lightgray;
+      border-radius: 30px;
+    }
+    #button:hover {
+      border-color: black;
     }
   </style>
   <body>
-    <form action="https://github.com/login/oauth/authorize" method="GET">
-      <input type="hidden" name="client_id" value="{{ client_id }}">
-      <input type="submit" value="Sign in with GitHub">
-    </form>
+    <div id="container">
+      <div id="button">
+        <img src="https://github.githubassets.com/images/modules/logos_page/Octocat.png">
+        <span>Sign in with GitHub</span>
+      </div>
+    </div>
+    <script>
+      $('#button').click(() => {
+        location.href = "https://github.com/login/oauth/authorize?client_id={{ client_id }}";
+      });
+    </script>
   </body>
 </html>

--- a/html/reaction.html
+++ b/html/reaction.html
@@ -32,7 +32,7 @@ limitations under the License.
   <body>
 
     <div id="header">
-      <div id="identity">{{ user_id }} <a href="/logout">logout</a></div>
+      <div id="identity"><img src="{{ user_avatar }}">{{ user_name }}&nbsp;<a href="/logout">logout</a></div>
       <div style="font-weight: bold;"><a href="/dataset/{{ name }}">{{ name }}</a>: {{ index }}</div>
       <div>Reaction ID <div id="reaction_id" class="edittext longtext"></div></div>
       <div>

--- a/py/migrate.py
+++ b/py/migrate.py
@@ -46,7 +46,7 @@ def migrate_all():
                 'INSERT INTO users VALUES (%s, %s, %s) ON CONFLICT DO NOTHING')
             with conn.cursor() as cursor:
                 timestamp = int(time.time())
-                cursor.execute(query, [user_id, user_id, timestamp])
+                cursor.execute(query, [user_id, None, timestamp])
             for name in os.listdir(f'db/{user_id}'):
                 if not name.endswith('.pbtxt'):
                     continue

--- a/py/serve.py
+++ b/py/serve.py
@@ -807,7 +807,7 @@ def make_github(login, email, avatar_url):
                 'UPDATE github SET email=%s, avatar_url=%s WHERE user_id=%s')
             cursor.execute(query, [email, avatar_url, user_id])
         else:
-            user_id = make_user(login) # Commits: end of transaction.
+            user_id = make_user(login)  # Commits: end of transaction.
             query = psycopg2.sql.SQL(
                 'INSERT INTO github VALUES (%s, %s, %s, %s)')
             cursor.execute(query, [user_id, login, email, avatar_url])

--- a/py/serve.py
+++ b/py/serve.py
@@ -735,7 +735,7 @@ def github_callback():
         'Authorization': f'token {access_token}',
     }
     # GitHub username is user['login'].
-    user = requests.get('https://api.github.com/user', headers=headers)
+    user = requests.get('https://api.github.com/user', headers=headers).json()
 
 
 @app.route('/authenticate', methods=['GET', 'POST'])

--- a/py/serve.py
+++ b/py/serve.py
@@ -738,7 +738,9 @@ def github_callback():
     response = requests.post('https://github.com/login/oauth/access_token',
                              data=data,
                              headers=headers)
-    access_token = response.json()['access_token']
+    access_token = response.json().get('access_token')
+    if access_token is None:
+        return flask.redirect('/login')
     headers = {
         'Accept': 'application/json',
         'Authorization': f'token {access_token}',

--- a/py/serve.py
+++ b/py/serve.py
@@ -722,6 +722,12 @@ def show_login():
 
 @app.route('/github-callback')
 def github_callback():
+    """Grant an access token via GitHub OAuth.
+
+    This endpoint's URL must be registered and bound to a client ID and a
+    secret key at
+    https://github.com/organizations/Open-Reaction-Database/settings/applications/
+    """
     code = flask.request.args.get('code')
     data = {
         'client_id': GH_CLIENT_ID,

--- a/schema.sql
+++ b/schema.sql
@@ -47,6 +47,13 @@ CREATE TABLE datasets (
   PRIMARY KEY (user_id, dataset_name)
 );
 
+CREATE TABLE github (
+  user_id CHARACTER(32) REFERENCES users,
+  login TEXT PRIMARY KEY,
+  email TEXT,
+  avatar_url TEXT
+);
+
 -- System users:
 --   "review" owns read-only datasets imported from GitHub pull requests.
 --   "test" owns datasets imported from db/ and used only in tests.

--- a/schema.sql
+++ b/schema.sql
@@ -47,16 +47,11 @@ CREATE TABLE datasets (
   PRIMARY KEY (user_id, dataset_name)
 );
 
-CREATE TABLE github (
-  user_id CHARACTER(32) REFERENCES users,
-  login TEXT PRIMARY KEY,
-  email TEXT,
-  avatar_url TEXT
-);
-
 -- System users:
 --   "review" owns read-only datasets imported from GitHub pull requests.
 --   "test" owns datasets imported from db/ and used only in tests.
 INSERT INTO users VALUES 
-   ('8df09572f3c74dbcb6003e2eef8e48fc', 'review', EXTRACT(EPOCH FROM NOW())),
-   ('680b0d9fe649417cb092d790907bd5a5', 'test', EXTRACT(EPOCH FROM NOW()));
+  -- review:
+  ('8df09572f3c74dbcb6003e2eef8e48fc', NULL, EXTRACT(EPOCH FROM NOW())),
+  -- test:
+  ('680b0d9fe649417cb092d790907bd5a5', NULL, EXTRACT(EPOCH FROM NOW()));


### PR DESCRIPTION
Cloned from #13 and elaborated.

- /login now shows only a "Login with GitHub" button. To impersonate, use "?&user=...".

- A new table called "github" binds the user ID to a GitHub login name, an email address, and an avatar URL.

- If the user has an entry in the github table, the page header shows their GitHub name and image.

Auto-login and legacy login still work. In those cases the header shows the user ID and the "ORD" project icon.