### PR TITLE
Add "sign in with GitHub" when in Guest Mode

### DIFF
--- a/css/reaction.css
+++ b/css/reaction.css
@@ -217,11 +217,22 @@ fieldset {
 #identity {
   float: right;
   width: 400px;
-  display: flex;
   align-items: center;
 }
 #identity img {
   width: 24px;
   margin-right: 8px;
   border-radius: 12px;
+}
+#login {
+  padding: 10px;
+  border-style: solid;
+  border-color: lightgray;
+  border-radius: 30px;
+  cursor: pointer;
+  width: fit-content;
+  display: flex;
+}
+#login:hover {
+  border-color: black;
 }

--- a/html/dataset.html
+++ b/html/dataset.html
@@ -64,7 +64,6 @@ limitations under the License.
       }
       #identity {
         float: right;
-        display: flex;
         align-items: center;
       }
       #identity img {
@@ -72,13 +71,41 @@ limitations under the License.
         margin-right: 8px;
         border-radius: 12px;
       }
+      #login {
+        padding: 10px;
+        border-style: solid;
+        border-color: lightgray;
+        border-radius: 30px;
+        cursor: pointer;
+        width: fit-content;
+        display: flex;
+      }
+      #login:hover {
+        border-color: black;
+      }
     </style>
     <script src="https://ajax.googleapis.com/ajax/libs/jquery/3.5.1/jquery.min.js"></script>
     <script src="/js/dataset.js"></script>
   </head>
   <body>
 
-    <div id="identity"><img src="{{ user_avatar }}">{{ user_name }}&nbsp;<a href="/logout">logout</a></div>
+    <div id="identity">
+      <div style="display: flex;"><img src="{{ user_avatar }}">{{ user_name }}</div>
+      {% if client_id %}
+      <div style="display: flex;">
+        <div style="padding: 10px; font-size: 16pt"><a href="https://docs.open-reaction-database.org/en/latest/editor.html#guest-mode" target="_blank">Guest Mode</a></div>
+        <div id="login">
+          <img src="https://github.githubassets.com/images/modules/logos_page/Octocat.png">
+          <span>Sign in with GitHub</span>
+        </div>
+      </div>
+      <script>
+        $('#login').click(() => {
+          location.href = "https://github.com/login/oauth/authorize?client_id={{ client_id }}";
+        });
+      </script>
+      {% endif %}
+    </div>
 
     <center>
       <h1><a href="/">Dataset</a>: {{ name }}.pbtxt</h1>

--- a/html/datasets.html
+++ b/html/datasets.html
@@ -57,7 +57,6 @@ limitations under the License.
     }
     #identity {
       float: right;
-      display: flex;
       align-items: center;
     }
     #identity img {
@@ -65,13 +64,41 @@ limitations under the License.
       margin-right: 8px;
       border-radius: 12px;
     }
+    #login {
+      padding: 10px;
+      border-style: solid;
+      border-color: lightgray;
+      border-radius: 30px;
+      cursor: pointer;
+      width: fit-content;
+      display: flex;
+    }
+    #login:hover {
+      border-color: black;
+    }
   </style>
   <script src="https://ajax.googleapis.com/ajax/libs/jquery/3.5.1/jquery.min.js"></script>
   <script src="https://cdn.jsdelivr.net/npm/popper.js@1.16.0/dist/umd/popper.min.js"></script>
   <script src="https://stackpath.bootstrapcdn.com/bootstrap/4.5.0/js/bootstrap.min.js"></script>
   <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/5.13.1/css/all.min.css">
   <body>
-    <div id="identity"><img src="{{ user_avatar }}">{{ user_name }}&nbsp;<a href="/logout">logout</a></div>
+    <div id="identity">
+      <div style="display: flex;"><img src="{{ user_avatar }}">{{ user_name }}</div>
+      {% if client_id %}
+      <div style="display: flex;">
+        <div style="padding: 10px; font-size: 16pt"><a href="https://docs.open-reaction-database.org/en/latest/editor.html#guest-mode" target="_blank">Guest Mode</a></div>
+        <div id="login">
+          <img src="https://github.githubassets.com/images/modules/logos_page/Octocat.png">
+          <span>Sign in with GitHub</span>
+        </div>
+      </div>
+      <script>
+        $('#login').click(() => {
+          location.href = "https://github.com/login/oauth/authorize?client_id={{ client_id }}";
+        });
+      </script>
+      {% endif %}
+    </div>
     <center>
       <h1>Available datasets</h1>
       <div id="saving" style="visibility: hidden;">saving</div>

--- a/html/reaction.html
+++ b/html/reaction.html
@@ -32,7 +32,23 @@ limitations under the License.
   <body>
 
     <div id="header">
-      <div id="identity"><img src="{{ user_avatar }}">{{ user_name }}&nbsp;<a href="/logout">logout</a></div>
+      <div id="identity">
+        <div style="display: flex;"><img src="{{ user_avatar }}">{{ user_name }}</div>
+        {% if client_id %}
+        <div style="display: flex;">
+          <div style="padding: 10px; font-size: 16pt"><a href="https://docs.open-reaction-database.org/en/latest/editor.html#guest-mode" target="_blank">Guest Mode</a></div>
+          <div id="login">
+            <img src="https://github.githubassets.com/images/modules/logos_page/Octocat.png">
+            <span>Sign in with GitHub</span>
+          </div>
+        </div>
+        <script>
+          $('#login').click(() => {
+            location.href = "https://github.com/login/oauth/authorize?client_id={{ client_id }}";
+          });
+        </script>
+        {% endif %}
+      </div>
       <div style="font-weight: bold;"><a href="/dataset/{{ name }}">{{ name }}</a>: {{ index }}</div>
       <div>Reaction ID <div id="reaction_id" class="edittext longtext"></div></div>
       <div>

--- a/py/serve.py
+++ b/py/serve.py
@@ -80,10 +80,15 @@ def show_datasets():
         cursor.execute(query, [flask.g.user_id])
         for row in cursor:
             names.append(row[0])
+    if len(flask.g.user_name) == 32:
+        client_id = GH_CLIENT_ID
+    else:
+        client_id = None
     return flask.render_template('datasets.html',
                                  names=sorted(names),
                                  user_avatar=flask.g.user_avatar,
-                                 user_name=flask.g.user_name)
+                                 user_name=flask.g.user_name,
+                                 client_id=client_id)
 
 
 @app.route('/dataset/<name>')
@@ -95,11 +100,16 @@ def show_dataset(name):
         reactions.append(reaction.identifiers)
     # Datasets belonging to the "review" user are immutable.
     freeze = flask.g.user_id == REVIEWER
+    if len(flask.g.user_name) == 32:
+        client_id = GH_CLIENT_ID
+    else:
+        client_id = None
     return flask.render_template('dataset.html',
                                  name=name,
                                  freeze=freeze,
                                  user_avatar=flask.g.user_avatar,
-                                 user_name=flask.g.user_name)
+                                 user_name=flask.g.user_name,
+                                 client_id=client_id)
 
 
 @app.route('/dataset/<name>/download')
@@ -200,12 +210,17 @@ def show_reaction(name, index):
         flask.abort(404)
     # Reactions belonging to the "review" user are immutable.
     freeze = flask.g.user_id == REVIEWER
+    if len(flask.g.user_name) == 32:
+        client_id = GH_CLIENT_ID
+    else:
+        client_id = None
     return flask.render_template('reaction.html',
                                  name=name,
                                  index=index,
                                  freeze=freeze,
                                  user_avatar=flask.g.user_avatar,
-                                 user_name=flask.g.user_name)
+                                 user_name=flask.g.user_name,
+                                 client_id=client_id)
 
 
 @app.route('/reaction/download', methods=['POST'])


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/952729/97645177-d37ec980-1a11-11eb-84ca-a87a8616904d.png)

("Guest Mode" and "Sign in with GitHub" disappear when the user is logged in with GitHub.)

* Adds a link to documentation about Guest Mode (https://github.com/Open-Reaction-Database/ord-schema/pull/497)
* Adds a "Sign in with GitHub" button when the user is in Guest Mode
* Removes the "logout" link (you can still log out by navigating to `/logout`)

Note that there is not currently any support for automatically migrating data a user may have entered in Guest Mode to the new account linked to their GitHub username. This gets a bit tricky if a user tries to do this more than once, since then we have to decide which account "wins", but it might be worth allowing this to happen the first time and then just using the GitHub-linked data on subsequent logins.

Partial fix for #19; still need to handle data migration.