### PR TITLE
Fix enumeration encoding error

### DIFF
--- a/html/datasets.html
+++ b/html/datasets.html
@@ -236,7 +236,7 @@ limitations under the License.
         spreadsheetReader.onload = spreadsheetReaderEvent => {
             spreadsheetData.resolve(spreadsheetReaderEvent.target.result);
         }
-        spreadsheetReader.readAsBinaryString(spreadsheetFile);
+        spreadsheetReader.readAsDataURL(spreadsheetFile);
 
         $.when(templateString, spreadsheetData, spreadsheetName).done(function(v1, v2, v3) {
           const xhr = new XMLHttpRequest();

--- a/py/serve.py
+++ b/py/serve.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 """A web editor for Open Reaction Database structures."""
 
+import base64
 import collections
 import contextlib
 import difflib
@@ -184,7 +185,10 @@ def enumerate_dataset():
     # pylint: disable=broad-except
     data = flask.request.get_json(force=True)
     basename, suffix = os.path.splitext(data['spreadsheet_name'])
-    spreadsheet_data = io.StringIO(data['spreadsheet_data'].lstrip('ï»¿'))
+    # Remove the data URL prefix; see
+    # https://developer.mozilla.org/en-US/docs/Web/API/FileReader/readAsDataURL.
+    match = re.fullmatch('data:.*?;base64,(.*)', data['spreadsheet_data'])
+    spreadsheet_data = io.BytesIO(base64.b64decode(match.group(1)))
     dataframe = templating.read_spreadsheet(spreadsheet_data, suffix=suffix)
     dataset = None
     try:

--- a/py/serve.py
+++ b/py/serve.py
@@ -176,7 +176,8 @@ def enumerate_dataset():
 
     Three pieces of information are expected to be POSTed in a json object:
         spreadsheet_name: the original filename of the uploaded spreadsheet.
-        spreadsheet_data: a string containing the contents of the spreadsheet.
+        spreadsheet_data: a base64-encoded string containing the contents of the
+            spreadsheet.
         template_string: a string containing a text-formatted Reaction proto,
             i.e., the contents of a pbtxt file.
     A new dataset is created from the template and spreadsheet using
@@ -185,10 +186,14 @@ def enumerate_dataset():
     # pylint: disable=broad-except
     data = flask.request.get_json(force=True)
     basename, suffix = os.path.splitext(data['spreadsheet_name'])
-    # Remove the data URL prefix; see
-    # https://developer.mozilla.org/en-US/docs/Web/API/FileReader/readAsDataURL.
-    match = re.fullmatch('data:.*?;base64,(.*)', data['spreadsheet_data'])
-    spreadsheet_data = io.BytesIO(base64.b64decode(match.group(1)))
+    if data['spreadsheet_data'].startswith('data:'):
+        # Remove the data URL prefix; see
+        # https://developer.mozilla.org/en-US/docs/Web/API/FileReader/readAsDataURL.
+        match = re.fullmatch('data:.*?;base64,(.*)', data['spreadsheet_data'])
+        spreadsheet_data = match.group(1)
+    else:
+        spreadsheet_data = data['spreadsheet_data']
+    spreadsheet_data = io.BytesIO(base64.b64decode(spreadsheet_data))
     dataframe = templating.read_spreadsheet(spreadsheet_data, suffix=suffix)
     dataset = None
     try:

--- a/py/serve_test.py
+++ b/py/serve_test.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 """Tests for editor.py.serve."""
 
+import base64
 import json
 import os
 import urllib
@@ -152,10 +153,12 @@ class ServeTest(parameterized.TestCase, absltest.TestCase):
             dataset = self._download_dataset(file_name)
             self.assertEmpty(dataset.reactions)
 
-    def test_enumerate_dataset(self):
+    @parameterized.parameters([b'', b'data:foo/bar;base64,'])
+    def test_enumerate_dataset(self, prefix):
         data = {'spreadsheet_name': 'test.csv'}
-        with open(os.path.join(self.testdata, 'nielsen_fig1.csv')) as f:
-            data['spreadsheet_data'] = f.read()
+        with open(os.path.join(self.testdata, 'nielsen_fig1.csv'), 'rb') as f:
+            data['spreadsheet_data'] = (prefix +
+                                        base64.b64encode(f.read())).decode()
         with open(os.path.join(self.testdata, 'reaction.pbtxt')) as f:
             data['template_string'] = f.read()
         response = self.client.post('/dataset/enumerate',


### PR DESCRIPTION
Encodes the spreadsheet as bytes and uses base64 for the JSON encoding during transfer.

Fixes #45 