### PR TITLE
Checkout specific ord-schema version in GitHub workflows

### DIFF
--- a/.github/workflows/cleanup.yml
+++ b/.github/workflows/cleanup.yml
@@ -16,6 +16,10 @@ name: Lint
 
 on: [pull_request, push]
 
+env:
+  # ord-schema is versioned to avoid breaking ord-editor.
+  ORD_SCHEMA_TAG: v0.1.1
+
 jobs:
   check_licenses:
     runs-on: ubuntu-latest
@@ -39,6 +43,7 @@ jobs:
       - uses: actions/checkout@v2
         with:
           repository: "Open-Reaction-Database/ord-schema"
+          ref: ${{ env.ORD_SCHEMA_TAG }}
           path: ord-schema
       - uses: s-weigand/setup-conda@v1
         with:
@@ -71,6 +76,7 @@ jobs:
       - uses: actions/checkout@v2
         with:
           repository: "Open-Reaction-Database/ord-schema"
+          ref: ${{ env.ORD_SCHEMA_TAG }}
           path: ord-schema
       - uses: actions/setup-java@v1
         with:
@@ -88,9 +94,6 @@ jobs:
       - name: Install ord-schema
         run: |
           cd "${GITHUB_WORKSPACE}/ord-schema"
-          # ord-schema is versioned to avoid breaking ord-editor.
-          git fetch --tags
-          git checkout "v0.1.1"
           pip install -r requirements.txt
           conda install -c rdkit rdkit
           python setup.py install

--- a/.github/workflows/cleanup.yml
+++ b/.github/workflows/cleanup.yml
@@ -88,6 +88,9 @@ jobs:
       - name: Install ord-schema
         run: |
           cd "${GITHUB_WORKSPACE}/ord-schema"
+          # ord-schema is versioned to avoid breaking ord-editor.
+          git fetch --tags
+          git checkout "v0.1.1"
           pip install -r requirements.txt
           conda install -c rdkit rdkit
           python setup.py install


### PR DESCRIPTION
When using GitHub workflows to test/lint code, we used to always get the most recent version of `ord-schema`, even if it was incompatible, which could cause tests to break. This fixes the version of `ord-schema`, similar to what we do in the Dockerfile.