### PR TITLE
Add "undo" after "remove".

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -36,6 +36,7 @@ RUN conda install -c rdkit \
     flask \
     gunicorn \
     nodejs \
+    python=3.7 \
     rdkit \
  && conda clean -afy
 

--- a/css/reaction.css
+++ b/css/reaction.css
@@ -59,13 +59,13 @@ body {
 .invalid {
   border: 2px solid red;
 }
-.add, #save, #download, .remove, #delete, .collapse, .validate_button, .validate_status, .validate_message, .validate_warning_status, .validate_warning_message, .tooltip > .tooltip-inner {
+.add, #save, #download, .remove, .undo, #delete, .collapse, .validate_button, .validate_status, .validate_message, .validate_warning_status, .validate_warning_message, .tooltip > .tooltip-inner {
   padding: 2px 4px;
   margin: 2px;
   display: inline-block;
   border-radius: 8px;
 }
-.add, #save, #download, .remove, #delete, .collapse, .validate_button {
+.add, #save, #download, .remove, .undo, #delete, .collapse, .validate_button {
   cursor: pointer;
 }
 .add {
@@ -75,7 +75,7 @@ body {
 #save, #download {
   background-color: lightgray;
 }
-.remove, #delete {
+.remove, .undo, #delete {
   background-color: pink;
 }
 .validate, .validate_status-message {

--- a/html/reaction.html
+++ b/html/reaction.html
@@ -114,7 +114,7 @@ limitations under the License.
                 <legend>
                   <span class="collapse"></span>
                   <span class="h3">Input</span>
-                  <div onclick="ord.inputs.remove(this);" class="remove">remove</div>
+                  <div onclick="ord.reaction.removeSlowly(this, '.input');" class="remove">remove</div>
                   <span class="validate" onclick="ord.inputs.validateInput($(this).closest('.input'))"></span>
                </legend>
                 <div>
@@ -1140,6 +1140,8 @@ limitations under the License.
       <tr><td>file format</td><td><div class="data_format edittext"></div></td></tr>
       </table>
     </div>
+
+    <div id="undo_template" class="undo" style="display: none;" onclick="ord.reaction.undoSlowly();">undo</div>
 
     <script>
         document.body.onload = async function () {

--- a/js/codes.js
+++ b/js/codes.js
@@ -58,7 +58,7 @@ function loadCode(name, code) {
 function unload(codes) {
   $('.setup_code').each(function(index, node) {
     node = $(node);
-    if (!node.attr('id')) {
+    if (!ord.reaction.isTemplateOrUndoBuffer(node)) {
       unloadCode(codes, node);
     }
   });

--- a/js/compounds.js
+++ b/js/compounds.js
@@ -231,8 +231,7 @@ function unloadIdentifiers(node) {
   const identifiers = [];
   $('.component_identifier', node).each(function(index, node) {
     node = $(node);
-    if (!node.attr('id')) {
-      // Not a template.
+    if (!ord.reaction.isTemplateOrUndoBuffer(node)) {
       const identifier = unloadIdentifier(node);
       if (!ord.reaction.isEmptyMessage(identifier)) {
         identifiers.push(identifier);
@@ -467,8 +466,7 @@ function drawIdentifier(node) {
     // Check if an existing SMILES/MolBlock identifier exists. If yes, remove.
     $('.component_identifier', node).each(function(index, node) {
       node = $(node);
-      if (!node.attr('id')) {
-        // Not a template.
+      if (!ord.reaction.isTemplateOrUndoBuffer(node)) {
         const identifier = unloadIdentifier(node);
         if ((identifier.getType() ===
              proto.ord.CompoundIdentifier.IdentifierType.SMILES) ||

--- a/js/dataset.js
+++ b/js/dataset.js
@@ -198,7 +198,7 @@ function unloadDataset() {
   const reactionIds = [];
   $('.other_reaction_id').each(function(index, node) {
     node = $(node);
-    if (!node.attr('id')) {
+    if (!ord.reaction.isTemplateOrUndoBuffer(node)) {
       reactionIds.push($('.other_reaction_id_text', node).text());
     }
   });

--- a/js/electro.js
+++ b/js/electro.js
@@ -125,7 +125,7 @@ function unload() {
   const measurements = [];
   $('.electro_measurement').each(function(index, node) {
     node = $(node);
-    if (!node.attr('id')) {
+    if (!ord.reaction.isTemplateOrUndoBuffer(node)) {
       const measurement = unloadMeasurement(node);
       if (!ord.reaction.isEmptyMessage(measurement)) {
         measurements.push(measurement);

--- a/js/features.js
+++ b/js/features.js
@@ -63,7 +63,7 @@ function unload(compoundNode) {
   const features = [];
   $('.component_feature', compoundNode).each(function(index, node) {
     node = $(node);
-    if (!node.attr('id')) {
+    if (!ord.reaction.isTemplateOrUndoBuffer(node)) {
       const feature = unloadFeature(node);
       if (!ord.reaction.isEmptyMessage(feature)) {
         features.push(feature);

--- a/js/identifiers.js
+++ b/js/identifiers.js
@@ -56,8 +56,7 @@ function unload() {
   const identifiers = [];
   $('.reaction_identifier').each(function(index, node) {
     node = $(node);
-    if (!node.attr('id')) {
-      // Not a template.
+    if (!ord.reaction.isTemplateOrUndoBuffer(node)) {
       const identifier = unloadIdentifier(node);
       if (!ord.reaction.isEmptyMessage(identifier)) {
         identifiers.push(identifier);

--- a/js/inputs.js
+++ b/js/inputs.js
@@ -24,7 +24,7 @@ exports = {
   add,
   validateInput,
   addInputByString,
-  remove,
+  updateSidebar
 };
 
 goog.require('ord.compounds');
@@ -149,8 +149,7 @@ function loadInputUnnamed(node, input) {
 function unload(inputs) {
   $('#inputs > div.input').each(function(index, node) {
     node = $(node);
-    if (!node.attr('id')) {
-      // Not a template.
+    if (!ord.reaction.isTemplateOrUndoBuffer(node)) {
       unloadInput(inputs, node);
     }
   });
@@ -255,14 +254,6 @@ function add(root, classes) {
   const nameNode = node.find('.input_name').first();
   nameNode.blur(updateSidebar);
   return node;
-}
-
-/**
- * Removes a reaction input section from the form.
- * @param {!Node} root Parent node for the input section to be removed.
- */
-function remove(root) {
-  ord.reaction.removeSlowly(root, '.input', updateSidebar);
 }
 
 /**

--- a/js/observations.js
+++ b/js/observations.js
@@ -56,8 +56,7 @@ function unload() {
   const observations = [];
   $('.observation').each(function(index, node) {
     node = $(node);
-    if (!node.attr('id')) {
-      // Not a template
+    if (!ord.reaction.isTemplateOrUndoBuffer(node)) {
       const observation = unloadObservation(node);
       if (!ord.reaction.isEmptyMessage(observation)) {
         observations.push(observation);

--- a/js/outcomes.js
+++ b/js/outcomes.js
@@ -151,8 +151,7 @@ function unload() {
   const outcomes = [];
   $('.outcome').each(function(index, node) {
     node = $(node);
-    if (!node.attr('id')) {
-      // Not a template.
+    if (!ord.reaction.isTemplateOrUndoBuffer(node)) {
       const outcome = unloadOutcome(node);
       if (!ord.reaction.isEmptyMessage(outcome)) {
         outcomes.push(outcome);
@@ -188,8 +187,7 @@ function unloadOutcome(node) {
   const analyses = outcome.getAnalysesMap();
   $('.outcome_analysis', node).each(function(index, node) {
     node = $(node);
-    if (!node.attr('id')) {
-      // Not a template.
+    if (!ord.reaction.isTemplateOrUndoBuffer(node)) {
       unloadAnalysis(node, analyses);
     }
   });

--- a/js/pressure.js
+++ b/js/pressure.js
@@ -101,7 +101,7 @@ function unload() {
   const measurements = [];
   $('.pressure_measurement').each(function(index, node) {
     node = $(node);
-    if (!node.attr('id')) {
+    if (!ord.reaction.isTemplateOrUndoBuffer(node)) {
       const measurement = unloadMeasurement(node);
       if (!ord.reaction.isEmptyMessage(measurement)) {
         measurements.push(measurement);

--- a/js/provenance.js
+++ b/js/provenance.js
@@ -121,8 +121,7 @@ function unload() {
   $('.provenance_modified', '#provenance_modifieds')
       .each(function(index, node) {
         node = $(node);
-        if (!node.attr('id')) {
-          // Not a template.
+        if (!ord.reaction.isTemplateOrUndoBuffer(node)) {
           const modified = unloadRecordEvent(node);
           if (!ord.reaction.isEmptyMessage(modified)) {
             modifieds.push(modified);

--- a/js/reaction.js
+++ b/js/reaction.js
@@ -667,7 +667,7 @@ function undoSlowly() {
   $('.undoable').removeClass('undoable').show('slow');
   $('.undo').not('#undo_template').hide('slow', function() {
     $(this).remove();
-    ord.inputs.updateSidebar()
+    ord.inputs.updateSidebar();
   });
   dirty();
 }
@@ -692,6 +692,7 @@ function makeUndoable(node) {
  * Supports unload() operations by filtering spurious selector matches due
  * either to DOM templates or elements the user has removed undoably.
  * @param {!Node node} node The DOM node to test for spuriousness.
+ * @return {boolean} True means ignore this node.
  */
 function isTemplateOrUndoBuffer(node) {
   return node.attr('id') || node.hasClass('undoable');

--- a/js/reaction.js
+++ b/js/reaction.js
@@ -683,7 +683,6 @@ function makeUndoable(node) {
   $('.undo').not('#undo_template').remove();
   const button = $('#undo_template').clone();
   button.removeAttr('id');
-  button.hide();
   node.after(button);
   button.show('slow');
 }

--- a/js/reaction.js
+++ b/js/reaction.js
@@ -41,7 +41,9 @@ exports = {
   getOptionalBool,
   freeze,
   setupObserver,
-  updateObserver
+  updateObserver,
+  undoSlowly,
+  isTemplateOrUndoBuffer
 };
 
 goog.require('ord.conditions');
@@ -637,10 +639,8 @@ function addSlowly(template, root) {
  * Removes from the DOM the nearest ancestor element matching the pattern.
  * @param {string} button The element from which to start the search.
  * @param {string} pattern The pattern for the element to remove.
- * @param {?function(): undefined} callback Function to execute in the
- *  callback to hide().
  */
-function removeSlowly(button, pattern, callback) {
+function removeSlowly(button, pattern) {
   const node = $(button).closest(pattern);
   // Must call necessary validators only after the node is removed,
   // but we can only figure out which validators these are before removal.
@@ -651,14 +651,50 @@ function removeSlowly(button, pattern, callback) {
     buttonsToClick =
         buttonsToClick.add($(this).children('legend').find('.validate_button'));
   });
+  makeUndoable(node);
   node.hide('slow', function() {
-    node.remove();
     buttonsToClick.trigger('click');
-    if (callback !== undefined) {
-      callback();
-    }
+    ord.inputs.updateSidebar();
   });
   dirty();
+}
+
+/**
+ * Reverses the hide() in the most recent invocation of removeSlowly().
+ * Removes the node's "undo" button. Does not trigger validation.
+ */
+function undoSlowly() {
+  $('.undoable').removeClass('undoable').show('slow');
+  $('.undo').not('#undo_template').hide('slow', function() {
+    $(this).remove();
+    ord.inputs.updateSidebar()
+  });
+  dirty();
+}
+
+/**
+ * Marks the given node for possible future undo. Adds an "undo" button to do
+ * it. Deletes any preexisting undoable nodes and undo buttons.
+ * @param {!Node} node The DOM fragment to hide and re-show.
+ */
+function makeUndoable(node) {
+  $('.undoable').remove();
+  node.addClass('undoable');
+  $('.undo').not('#undo_template').remove();
+  const button = $('#undo_template').clone();
+  button.removeAttr('id');
+  button.hide();
+  node.after(button);
+  button.show('slow');
+}
+
+/**
+ * Supports unload() operations by filtering spurious selector matches due
+ * either to DOM templates or elements the user has removed undoably.
+ * @param {!Node node} node The DOM node to test for spuriousness.
+ */
+function isTemplateOrUndoBuffer(node) {
+  return node.attr('id') || node.hasClass('undoable');
 }
 
 /**

--- a/js/setups.js
+++ b/js/setups.js
@@ -156,7 +156,7 @@ function unloadVessel() {
   const preparations = [];
   $('.setup_vessel_preparation').each(function(index, node) {
     node = $(node);
-    if (node.attr('id')) {
+    if (ord.reaction.isTemplateOrUndoBuffer(node)) {
       // The template.
       return;
     }
@@ -173,8 +173,7 @@ function unloadVessel() {
   const attachments = [];
   $('.setup_vessel_attachment').each(function(index, node) {
     node = $(node);
-    if (node.attr('id')) {
-      // The template.
+    if (ord.reaction.isTemplateOrUndoBuffer(node)) {
       return;
     }
     const attachment = new proto.ord.VesselAttachment();

--- a/js/temperature.js
+++ b/js/temperature.js
@@ -89,7 +89,7 @@ function unload() {
   const measurements = [];
   $('.temperature_measurement').each(function(index, node) {
     node = $(node);
-    if (!node.attr('id')) {
+    if (!ord.reaction.isTemplateOrUndoBuffer(node)) {
       const measurement = unloadMeasurement(node);
       if (!ord.reaction.isEmptyMessage(measurement)) {
         measurements.push(measurement);

--- a/js/workups.js
+++ b/js/workups.js
@@ -139,7 +139,7 @@ function unload() {
   const workups = [];
   $('.workup').each(function(index, node) {
     node = $(node);
-    if (!node.attr('id')) {
+    if (!ord.reaction.isTemplateOrUndoBuffer(node)) {
       const workup = unloadWorkup(node);
       if (!ord.reaction.isEmptyMessage(workup)) {
         workups.push(workup);


### PR DESCRIPTION
The "remove" action used to remove a DOM fragment. Now it now does four things:

1) hides its DOM fragment;
2) adds an "undo" button that will show it again;
3) removes any hidden DOM fragments and previously shown "undo" buttons;
4) updates the "Inputs" navigation sidebar in case the change affects inputs.

This change also adds a new "undo" action. It does these things:

1) shows the hidden DOM fragment;
2) removes the "undo" button;
3) updates the "Inputs" navigation sidebar.

When a reaction is saved, the hidden fragments are ignored.