### PR TITLE
Render product compound identifiers

### DIFF
--- a/js/compounds.js
+++ b/js/compounds.js
@@ -32,6 +32,7 @@ exports = {
   loadFeature,
   unloadFeature,
   unloadIdentifiers,
+  renderCompound,
 };
 
 goog.require('ord.amounts');

--- a/js/products.js
+++ b/js/products.js
@@ -597,4 +597,5 @@ function validateMeasurement(node, validateNode) {
 function validateProduct(node, validateNode) {
   const product = unloadProduct(node);
   ord.reaction.validate(product, 'ProductCompound', node, validateNode);
+  ord.compounds.renderCompound(node, product);
 }


### PR DESCRIPTION
Product compound identifiers are not being rendered in the editor.