### PR TITLE
Add script for launching ord-editor on GCP

### DIFF
--- a/.env
+++ b/.env
@@ -1,0 +1,12 @@
+# GitHub OAuth Apps settings.
+# See https://github.com/organizations/open-reaction-database/settings/applications.
+GH_CLIENT_ID=
+GH_CLIENT_SECRET=
+# Mount point on the VM for the editor database.
+#
+# On GCP, the mount location should be on a persistent disk that
+# will not disappear when the image is restarted. When running
+# locally, this can be something like "${HOME}/ord-editor-data".
+ORD_EDITOR_MOUNT=
+# Password for the postgres database.
+ORD_EDITOR_POSTGRES_PASSWORD=

--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,5 @@ ketcher
 protobuf-*
 node_modules
 package-lock.json
+# docker-compose environment variables
+.env

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -14,20 +14,15 @@
 
 # docker-compose configuration for the ORD editor + postgres backend database.
 #
-# Two environment variables are required:
-#   * ORD_EDITOR_POSTGRES_PASSWORD: The postgres password.
-#   * ORD_EDITOR_MOUNT: Mount location for the volume on which the database
-#     is stored. This is designed for use with GCP, where the mount location
-#     refers to a persistent disk that will not disappear when the image is
-#     restarted. See https://github.com/docker-library/docs/blob/master/postgres/README.md#pgdata
-#     for more details. When running locally, this should be set to something
-#     like "${HOME}/ord-editor-data".
+# The required environment variables should be set in .env to keep everything
+# in one place and make it easier to update VMs on GCP.
 
 version: "3"
 services:
   db:
     image: "postgres"
     environment:
+      # See https://github.com/docker-library/docs/blob/master/postgres/README.md#pgdata.
       - PGDATA=/var/lib/postgresql/data/pgdata
       - POSTGRES_PASSWORD=${ORD_EDITOR_POSTGRES_PASSWORD}
     volumes:

--- a/launch.sh
+++ b/launch.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+# Copyright 2020 Open Reaction Database Project Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+docker build -t openreactiondatabase/ord-editor .
+docker-compose --env-file .env up -d


### PR DESCRIPTION
The new `.env` file keeps everything in one place. It is added to `.gitignore` so we don't accidentally leak the filled-out variables publicly.

See https://docs.docker.com/compose/environment-variables/#the-env-file