### PR TITLE
Use .pb for the editor backend

### DIFF
--- a/.github/workflows/cleanup.yml
+++ b/.github/workflows/cleanup.yml
@@ -17,7 +17,7 @@ name: Lint
 on: [pull_request, push]
 
 env:
-  ORD_SCHEMA_TAG: v0.2.3
+  ORD_SCHEMA_TAG: v0.2.6
 
 jobs:
   check_licenses:

--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -19,15 +19,27 @@ on: [pull_request, push]
 env:
   # See https://dev.to/dtinth/caching-docker-builds-in-github-actions-which-approach-is-the-fastest-a-research-18ei.
   CACHE_TARGET: "docker.pkg.github.com/open-reaction-database/ord-editor/editor-cache"
+  ORD_SCHEMA_TAG: v0.2.6
 
 jobs:
   test_editor:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2
-    - uses: actions/setup-python@v2
+    - uses: actions/checkout@v2
       with:
-        python-version: '3.x'
+        repository: "Open-Reaction-Database/ord-schema"
+        ref: ${{ env.ORD_SCHEMA_TAG }}
+        path: ord-schema
+    - uses: s-weigand/setup-conda@v1
+      with:
+        python-version: 3.7
+    - name: Install ord-schema
+      run: |
+        cd "${GITHUB_WORKSPACE}/ord-schema"
+        pip install -r requirements.txt
+        conda install -c rdkit rdkit
+        python setup.py install
     - uses: actions/setup-node@v1
     - name: Setup docker cache
       run: |

--- a/html/dataset.html
+++ b/html/dataset.html
@@ -42,7 +42,7 @@ limitations under the License.
       .paratext {
         height: 100px;
       }
-      .add, #save, .remove, #download {
+      .add, #save, .remove, .download {
         padding: 2px 4px;
         margin: 2px;
         display: inline-block;
@@ -53,7 +53,7 @@ limitations under the License.
         background-color: lightgreen;
         margin-top: 12px;
       }
-      #save, #download {
+      #save, .download {
         background-color: lightgray;
       }
       .remove {
@@ -118,7 +118,8 @@ limitations under the License.
       <h1><a href="/">Dataset</a>: {{ name }}.pbtxt</h1>
     </center>
     <div id="top_buttons">
-      <div id="download" onclick="ord.dataset.download();">download</div>
+      <div class="download" id="download_pb" onclick="ord.dataset.download('pb');">download pb</div>
+      <div class="download" id="download_pbtxt" onclick="ord.dataset.download('pbtxt');">download pbtxt</div>
       <div id="save" onclick="ord.dataset.commit();" style="visibility: hidden;">save</div>
       <div id="delete" class="remove" style="float: none;" onclick="if(confirm('Are you sure you want to delete this Dataset? This cannot be undone.')) { location.href='/dataset/{{ name }}/delete'; }">delete</div>
     </div>

--- a/js/dataset.js
+++ b/js/dataset.js
@@ -92,16 +92,17 @@ function commit() {
 
 /**
  * Downloads the current dataset.
+ * @param {string} kind Serialization format; one of 'pb' or 'pbtxt'.
  */
-function download() {
+function download(kind) {
   const xhr = new XMLHttpRequest();
-  xhr.open('GET', '/dataset/' + session.fileName + '/download');
+  xhr.open('GET', '/dataset/' + session.fileName + '/download/' + kind);
   xhr.onload = () => {
     // Make the browser write the file.
     const url = URL.createObjectURL(new Blob([xhr.response]));
     const link = document.createElement('a');
     link.href = url;
-    link.setAttribute('download', session.fileName + '.pbtxt');
+    link.setAttribute('download', session.fileName + '.' + kind);
     document.body.appendChild(link);
     link.click();
   };

--- a/py/serve.py
+++ b/py/serve.py
@@ -115,9 +115,10 @@ def show_dataset(name):
                                  client_id=client_id)
 
 
+@app.route('/dataset/<name>/download')
 @app.route('/dataset/<name>/download/<kind>')
-def download_dataset(name, kind):
-    """Returns a pbtxt from the datasets table as an attachment."""
+def download_dataset(name, kind='pb'):
+    """Returns a pb or pbtxt from the datasets table as an attachment."""
     dataset = get_dataset(name)
     data = None
     if kind == 'pb':

--- a/py/serve.py
+++ b/py/serve.py
@@ -28,6 +28,7 @@ import uuid
 
 import flask
 import github
+import google.protobuf.message
 from google.protobuf import text_format
 import psycopg2
 import psycopg2.sql
@@ -75,11 +76,10 @@ def show_root():
 
 @app.route('/datasets')
 def show_datasets():
-    """Lists all the user's pbtxts in the datasets table."""
+    """Lists all the user's datasets in the datasets table."""
     names = []
     with flask.g.db.cursor() as cursor:
-        query = psycopg2.sql.SQL(
-            'SELECT dataset_name FROM datasets WHERE user_id=%s')
+        query = psycopg2.sql.SQL('SELECT name FROM datasets WHERE user_id=%s')
         cursor.execute(query, [flask.g.user_id])
         for row in cursor:
             names.append(row[0])
@@ -118,12 +118,12 @@ def show_dataset(name):
 @app.route('/dataset/<name>/download')
 def download_dataset(name):
     """Returns a pbtxt from the datasets table as an attachment."""
-    pbtxt = get_pbtxt(name)
-    data = io.BytesIO(pbtxt.encode('utf8'))
+    dataset = get_dataset(name)
+    data = io.BytesIO(dataset.SerializeToString(deterministic=True))
     return flask.send_file(data,
                            mimetype='application/protobuf',
                            as_attachment=True,
-                           attachment_filename=f'{name}.pbtxt')
+                           attachment_filename=f'{name}.pb')
 
 
 @app.route('/dataset/<name>/upload', methods=['POST'])
@@ -133,13 +133,18 @@ def upload_dataset(name):
         response = flask.make_response(f'dataset already exists: {name}', 409)
         flask.abort(response)
     try:
+        try:
+            dataset = dataset_pb2.Dataset.FromString(flask.request.get_data())
+        except (google.protobuf.message.DecodeError, TypeError):
+            dataset = dataset_pb2.Dataset()
+            text_format.Parse(flask.request.get_data(as_text=True), dataset)
+        user_id = flask.g.user_id
         with flask.g.db.cursor() as cursor:
             query = psycopg2.sql.SQL('INSERT INTO datasets VALUES (%s, %s, %s)')
-            pbtxt = flask.request.get_data().decode('utf-8')
-            dataset = dataset_pb2.Dataset()
-            text_format.Parse(pbtxt, dataset)  # Validate.
-            user_id = flask.g.user_id
-            cursor.execute(query, [user_id, name, pbtxt])
+            cursor.execute(
+                query,
+                [user_id, name,
+                 dataset.SerializeToString(deterministic=True)])
             flask.g.db.commit()
         return 'ok'
     except Exception as error:  # pylint: disable=broad-except
@@ -165,7 +170,7 @@ def delete_dataset(name):
     """Removes a Dataset."""
     with flask.g.db.cursor() as cursor:
         query = psycopg2.sql.SQL(
-            'DELETE FROM datasets WHERE user_id=%s AND dataset_name=%s')
+            'DELETE FROM datasets WHERE user_id=%s AND name=%s')
         user_id = flask.g.user_id
         cursor.execute(query, [user_id, name])
         flask.g.db.commit()
@@ -569,8 +574,7 @@ def show_submissions():
         return flask.redirect('/')
     pull_requests = collections.defaultdict(list)
     with flask.g.db.cursor() as cursor:
-        query = psycopg2.sql.SQL(
-            'SELECT dataset_name FROM datasets WHERE user_id=%s')
+        query = psycopg2.sql.SQL('SELECT name FROM datasets WHERE user_id=%s')
         cursor.execute(query, [REVIEWER])
         for row in cursor:
             name = row[0]
@@ -599,17 +603,25 @@ def sync_reviews():
         # First reset all datasets under review.
         query = psycopg2.sql.SQL('DELETE FROM datasets WHERE user_id=%s')
         cursor.execute(query, [REVIEWER])
-        # Then import all pbtxts from open PR's.
+        # Then import all datasets from open PR's.
         for pr in repo.get_pulls():
             for remote in pr.get_files():
-                if not remote.filename.endswith('.pbtxt'):
+                response = requests.get(remote.raw_url)
+                if remote.filename.endswith('.pbtxt'):
+                    dataset = dataset_pb2.Dataset()
+                    text_format.Parse(response.text, dataset)
+                elif remote.filename.endswith('.pb'):
+                    dataset = dataset_pb2.Dataset.FromString(response.content)
+                else:
                     continue
-                pbtxt = requests.get(remote.raw_url).text
                 name = 'PR_%d ___%s___ %s' % (pr.number, pr.title,
                                               remote.filename[:-6])
                 query = psycopg2.sql.SQL(
                     'INSERT INTO datasets VALUES (%s, %s, %s)')
-                cursor.execute(query, [user_id, name, pbtxt])
+                cursor.execute(query, [
+                    user_id, name,
+                    dataset.SerializeToString(deterministic=True)
+                ])
     flask.g.db.commit()
     return flask.redirect('/review')
 
@@ -627,22 +639,14 @@ def prevent_caching(response):
 
 
 def get_dataset(name):
-    """Reads a pbtxt proto from the datasets table and parses it."""
-    pbtxt = get_pbtxt(name)
-    dataset = dataset_pb2.Dataset()
-    text_format.Parse(pbtxt, dataset)
-    return dataset
-
-
-def get_pbtxt(name):
-    """Reads a pbtxt proto from the datasets."""
+    """Reads a serialized proto from the datasets table and parses it."""
     with flask.g.db.cursor() as cursor:
         query = psycopg2.sql.SQL(
-            'SELECT pbtxt FROM datasets WHERE user_id=%s AND dataset_name=%s')
+            'SELECT serialized FROM datasets WHERE user_id=%s AND name=%s')
         cursor.execute(query, [flask.g.user_id, name])
         if cursor.rowcount == 0:
             flask.abort(404)
-        return cursor.fetchone()[0]
+        return dataset_pb2.Dataset.FromString(cursor.fetchone()[0])
 
 
 def put_dataset(name, dataset):
@@ -650,10 +654,10 @@ def put_dataset(name, dataset):
     with flask.g.db.cursor() as cursor:
         query = psycopg2.sql.SQL(
             'INSERT INTO datasets VALUES (%s, %s, %s) '
-            'ON CONFLICT (user_id, dataset_name) DO UPDATE SET pbtxt=%s')
+            'ON CONFLICT (user_id, name) DO UPDATE SET serialized=%s')
         user_id = flask.g.user_id
-        pbtxt = text_format.MessageToString(dataset, as_utf8=True)
-        cursor.execute(query, [user_id, name, pbtxt, pbtxt])
+        serialized = dataset.SerializeToString(deterministic=True)
+        cursor.execute(query, [user_id, name, serialized, serialized])
         flask.g.db.commit()
 
 
@@ -665,7 +669,7 @@ def lock(file_name):
     through browser file uploads and so must be merged with Dataset protos on
     the server. The file uploads and the Dataset proto arrive asynchronously in
     concurrent connections. Locks ensure that only one request at a time
-    accesses a Datset's .pbtxt file.
+    accesses a Datset's .pb file.
 
     Args:
         file_name: Name of the file to pass to the fcntl system call.
@@ -756,7 +760,7 @@ def get_path(file_name, suffix=''):
 
     Args:
         file_name: Text filename.
-        suffix: Text filename suffix. Defaults to '.pbtxt'.
+        suffix: Text filename suffix. Defaults to ''.
 
     Returns:
         Path to the requested file.
@@ -768,7 +772,7 @@ def exists_dataset(name):
     """True if a dataset with the given name is defined for the current user."""
     with flask.g.db.cursor() as cursor:
         query = psycopg2.sql.SQL(
-            'SELECT 1 FROM datasets WHERE user_id=%s AND dataset_name=%s')
+            'SELECT 1 FROM datasets WHERE user_id=%s AND name=%s')
         user_id = flask.g.user_id
         cursor.execute(query, [user_id, name])
         return cursor.rowcount > 0

--- a/py/serve.py
+++ b/py/serve.py
@@ -115,15 +115,21 @@ def show_dataset(name):
                                  client_id=client_id)
 
 
-@app.route('/dataset/<name>/download')
-def download_dataset(name):
+@app.route('/dataset/<name>/download/<kind>')
+def download_dataset(name, kind):
     """Returns a pbtxt from the datasets table as an attachment."""
     dataset = get_dataset(name)
-    data = io.BytesIO(dataset.SerializeToString(deterministic=True))
+    data = None
+    if kind == 'pb':
+        data = io.BytesIO(dataset.SerializeToString(deterministic=True))
+    elif kind == 'pbtxt':
+        data = io.BytesIO(text_format.MessageToBytes(dataset))
+    else:
+        flask.abort(flask.make_response(f'unsupported format: {kind}', 406))
     return flask.send_file(data,
                            mimetype='application/protobuf',
                            as_attachment=True,
-                           attachment_filename=f'{name}.pb')
+                           attachment_filename=f'{name}.{kind}')
 
 
 @app.route('/dataset/<name>/upload', methods=['POST'])

--- a/py/serve_test.py
+++ b/py/serve_test.py
@@ -23,6 +23,7 @@ from absl.testing import parameterized
 from google.protobuf import text_format
 from rdkit import Chem
 
+from ord_schema import message_helpers
 from ord_schema.proto import dataset_pb2
 from ord_schema.proto import reaction_pb2
 
@@ -58,6 +59,7 @@ class ServeTest(parameterized.TestCase, absltest.TestCase):
 
     def setUp(self):
         super().setUp()
+        self.test_directory = self.create_tempdir()
         serve.app.config['TESTING'] = True
         self.client = serve.app.test_client()
         # GET requests automatically login as the test user.
@@ -120,6 +122,35 @@ class ServeTest(parameterized.TestCase, absltest.TestCase):
         response = self.client.get(f'/dataset/{file_name}/download',
                                    follow_redirects=True)
         self.assertEqual(response.status_code, expected)
+        if response.status_code == 200:
+            # Make sure it parses.
+            filename = os.path.join(self.test_directory, 'dataset.pb')
+            with open(filename, 'wb') as f:
+                f.write(response.data)
+            message_helpers.load_message(filename, dataset_pb2.Dataset)
+
+    @parameterized.parameters([
+        ('dataset', 'pb', 200),
+        ('dataset', 'pbtxt', 200),
+        ('../dataset', 'pb', 404),
+        ('../dataset', 'pbtxt', 404),
+        (urllib.parse.quote_plus('../dataset'), 'pb', 404),
+        (urllib.parse.quote_plus('../dataset'), 'pbtxt', 404),
+        ('/foo/bar', 'pb', 404),
+        ('/foo/bar', 'pbtxt', 404),
+        ('other', 'pb', 404),
+        ('other', 'pbtxt', 404),
+    ])
+    def test_download_dataset_with_kind(self, file_name, kind, expected):
+        response = self.client.get(f'/dataset/{file_name}/download/{kind}',
+                                   follow_redirects=True)
+        self.assertEqual(response.status_code, expected)
+        if response.status_code == 200:
+            # Make sure it parses.
+            filename = os.path.join(self.test_directory, f'dataset.{kind}')
+            with open(filename, 'wb') as f:
+                f.write(response.data)
+            message_helpers.load_message(filename, dataset_pb2.Dataset)
 
     @parameterized.parameters([
         ('dataset', 409, True),

--- a/py/serve_test.py
+++ b/py/serve_test.py
@@ -84,9 +84,7 @@ class ServeTest(parameterized.TestCase, absltest.TestCase):
         response = self.client.get(f'/dataset/{name}/download',
                                    follow_redirects=True)
         self.assertEqual(response.status_code, 200)
-        dataset = dataset_pb2.Dataset()
-        text_format.Parse(response.data, dataset)
-        return dataset
+        return dataset_pb2.Dataset.FromString(response.data)
 
     def _upload_dataset(self, dataset, name):
         """Uploads a Dataset for testing."""
@@ -137,8 +135,7 @@ class ServeTest(parameterized.TestCase, absltest.TestCase):
             response = self.client.get(f'/dataset/{file_name}/download',
                                        follow_redirects=True)
             self.assertEqual(response.status_code, 200)
-            downloaded_dataset = dataset_pb2.Dataset()
-            text_format.Parse(response.data, downloaded_dataset)
+            downloaded_dataset = dataset_pb2.Dataset.FromString(response.data)
             self.assertEqual(downloaded_dataset, dataset)
 
     @parameterized.parameters([
@@ -169,8 +166,7 @@ class ServeTest(parameterized.TestCase, absltest.TestCase):
         response = self.client.get('/dataset/test_dataset/download',
                                    follow_redirects=True)
         self.assertEqual(response.status_code, 200)
-        dataset = dataset_pb2.Dataset()
-        text_format.Parse(response.data, dataset)
+        dataset = dataset_pb2.Dataset.FromString(response.data)
         self.assertLen(dataset.reactions, 80)
 
     @parameterized.parameters([

--- a/py/serve_test.py
+++ b/py/serve_test.py
@@ -122,13 +122,19 @@ class ServeTest(parameterized.TestCase, absltest.TestCase):
         self.assertEqual(response.status_code, expected)
 
     @parameterized.parameters([
-        ('dataset', 409),
-        ('other', 200),
+        ('dataset', 409, True),
+        ('dataset', 409, False),
+        ('other', 200, True),
+        ('other', 200, False),
     ])
-    def test_upload_dataset(self, file_name, expected):
+    def test_upload_dataset(self, file_name, expected, as_text):
         dataset = self._get_dataset()
+        if as_text:
+            data = text_format.MessageToString(dataset)
+        else:
+            data = dataset.SerializeToString()
         response = self.client.post(f'/dataset/{file_name}/upload',
-                                    data=text_format.MessageToString(dataset),
+                                    data=data,
                                     follow_redirects=True)
         self.assertEqual(response.status_code, expected)
         if response.status_code == 200:

--- a/schema.sql
+++ b/schema.sql
@@ -42,9 +42,9 @@ CREATE TABLE logins (
 
 CREATE TABLE datasets (
   user_id CHARACTER(32) REFERENCES users,
-  dataset_name TEXT NOT NULL,
-  pbtxt TEXT NOT NULL,
-  PRIMARY KEY (user_id, dataset_name)
+  name TEXT NOT NULL,
+  serialized BYTEA NOT NULL,
+  PRIMARY KEY (user_id, name)
 );
 
 -- System users:


### PR DESCRIPTION
Resolves #39; closes #77

* Adjusts the backend schema:
  * `pbtxt (TEXT)` -> `serialized (BYTEA)`
  * `dataset_name` -> `name` (to avoid stutter)
* Datasets are now downloaded as .pb (reactions still download as .pbtxt)
* Uploads are allowed in either .pb or .pbtxt format