### PR TITLE
Refactor reaction.js to remove circular dependencies

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -65,7 +65,7 @@ RUN npm install google-closure-compiler
 WORKDIR ..
 RUN git clone https://github.com/Open-Reaction-Database/ord-schema.git
 WORKDIR ord-schema
-ARG ORD_SCHEMA_TAG=v0.2.3
+ARG ORD_SCHEMA_TAG=v0.2.7
 RUN git fetch --tags && git checkout "${ORD_SCHEMA_TAG}"
 RUN pip install -r requirements.txt
 RUN python setup.py install

--- a/html/reaction.html
+++ b/html/reaction.html
@@ -64,7 +64,7 @@ limitations under the License.
         <span>|</span>
         <div id="save" onclick="ord.reaction.commit();" style="visibility: hidden;">save</div>
         <span id="reaction_validate" class="validate" onclick="ord.reaction.validateReaction()"></span>
-        <span id="toggle_autosave" onclick="ord.reaction.toggleAutosave()"></span>
+        <span id="toggle_autosave" onclick="ord.utils.toggleAutosave()"></span>
       </div>
     </div>
 
@@ -1199,9 +1199,9 @@ limitations under the License.
             const section = $(event.target).attr('data-section');
             $('#section_' + section)[0].scrollIntoView({behavior: 'smooth'});
           });
-          ord.reaction.setupObserver();
+          ord.utils.setupObserver();
           {% if freeze %}
-            ord.reaction.freeze();
+            ord.utils.freeze();
           {% endif %}
           if (location.hash) {
             const section = location.hash.replace('#', '');

--- a/html/reaction.html
+++ b/html/reaction.html
@@ -115,7 +115,7 @@ limitations under the License.
                 <legend>
                   <span class="collapse"></span>
                   <span class="h3">Input</span>
-                  <div onclick="ord.reaction.removeSlowly(this, '.input');" class="remove">remove</div>
+                  <div onclick="ord.utils.removeSlowly(this, '.input');" class="remove">remove</div>
                   <span class="validate" onclick="ord.inputs.validateInput($(this).closest('.input'))"></span>
                </legend>
                 <div>
@@ -186,7 +186,7 @@ limitations under the License.
                 <legend>
                   <span class="collapse"></span>
                   <span class="h4">Component</span>
-                  <div onclick="ord.reaction.removeSlowly(this, '.component');" class="remove">remove</div>
+                  <div onclick="ord.utils.removeSlowly(this, '.component');" class="remove">remove</div>
                   <span class="validate" onclick="ord.compounds.validateCompound($(this).closest('.component'))"></span>
                 </legend>
                 <table class="component_role_limiting">
@@ -265,7 +265,7 @@ limitations under the License.
                 <legend>
                   <span class="collapse"></span>
                   <span class="h5">Feature</span>
-                  <div onclick="ord.reaction.removeSlowly(this, '.feature');" class="remove">remove</div>
+                  <div onclick="ord.utils.removeSlowly(this, '.feature');" class="remove">remove</div>
                 </legend>
                 <table class="message">
                   <tr><td>name</td><td><div class="feature_name edittext"></div></td></tr>
@@ -279,7 +279,7 @@ limitations under the License.
                   <td>value</td>
                   <td>
                     <div class="component_identifier_value edittext longtext"></div>
-                    <span class="fa fa-upload text_upload" aria-hidden="true" style="cursor:pointer;" onclick="ord.reaction.setTextFromFile($(this).closest('.component_identifier'), 'component_identifier_value');"></span>
+                    <span class="fa fa-upload text_upload" aria-hidden="true" style="cursor:pointer;" onclick="ord.utils.setTextFromFile($(this).closest('.component_identifier'), 'component_identifier_value');"></span>
                   </td>
                 </tr>
                 <tr>
@@ -290,7 +290,7 @@ limitations under the License.
                   <td>details</td>
                   <td>
                     <div class="component_identifier_details edittext longtext"></div>
-                    <div onclick="ord.reaction.removeSlowly(this, '.component_identifier');" class="remove">remove</div>
+                    <div onclick="ord.utils.removeSlowly(this, '.component_identifier');" class="remove">remove</div>
                   </td>
                 </tr>
               </table>
@@ -301,7 +301,7 @@ limitations under the License.
               details <div class="component_compound_preparation_details edittext"></div>
               <span class="component_compound_preparation_reaction_id">reaction ID</span>
               <div class="component_compound_preparation_reaction component_compound_preparation_reaction_id edittext"></div>
-              <div onclick="ord.reaction.removeSlowly(this, '.component_preparation');" class="remove">remove</div>
+              <div onclick="ord.utils.removeSlowly(this, '.component_preparation');" class="remove">remove</div>
             </div>
 
             <div id="crude_template" class="crude" style="display: none;">
@@ -309,7 +309,7 @@ limitations under the License.
                 <legend>
                   <span class="collapse"></span>
                   <span class="h4">Crude Component</span>
-                  <div onclick="ord.reaction.removeSlowly(this, '.crude');" class="remove">remove</div>
+                  <div onclick="ord.utils.removeSlowly(this, '.crude');" class="remove">remove</div>
                   <span data-toggle="tooltip" data-placement="right" title="Crude components use non-isolated material from another reaction as input. The reaction ID must correspond to another reaction in this same dataset.">
                       <span class="fa fa-question-circle" aria-hidden="true"></span>
                     </span>
@@ -371,7 +371,7 @@ limitations under the License.
             <div id="setup_vessel_preparation_template" class="setup_vessel_preparation" style="display: none;">
               preparation<div class="setup_vessel_preparation_type selector" data-proto="VesselPreparation_VesselPreparationType"></div>
               details <div class="setup_vessel_preparation_details edittext"></div>
-              <div onclick="ord.reaction.removeSlowly(this, '.setup_vessel_preparation');" class="remove">remove</div>
+              <div onclick="ord.utils.removeSlowly(this, '.setup_vessel_preparation');" class="remove">remove</div>
             </div>
           </div>
           <div onclick="ord.setups.addVesselPreparation();" class="add">+ add preparation</div>
@@ -385,7 +385,7 @@ limitations under the License.
             <div id="setup_vessel_attachment_template" class="setup_vessel_attachment" style="display: none;">
               attachment<div class="setup_vessel_attachment_type selector" data-proto="VesselAttachment_VesselAttachmentType"></div>
               details <div class="setup_vessel_attachment_details edittext"></div>
-              <div onclick="ord.reaction.removeSlowly(this, '.setup_vessel_attachment');" class="remove">remove</div>
+              <div onclick="ord.utils.removeSlowly(this, '.setup_vessel_attachment');" class="remove">remove</div>
             </div>
           </div>
           <div onclick="ord.setups.addVesselAttachment();" class="add">+ add attachment</div>
@@ -396,7 +396,7 @@ limitations under the License.
               <legend>
                 <span class="collapse"></span>
                 <span class="h3">Automation code</span>
-                <div onclick="ord.reaction.removeSlowly(this, '.setup_code');" class="remove">remove</div>
+                <div onclick="ord.utils.removeSlowly(this, '.setup_code');" class="remove">remove</div>
                 <span data-toggle="tooltip" data-placement="right" title="Details of the exact automation procedure required to perform the reaction.">
                   <span class="fa fa-question-circle" aria-hidden="true"></span>
                 </span>
@@ -435,7 +435,7 @@ limitations under the License.
                 <legend>
                   <span class="collapse"></span>
                   <span class="h4">Measurement</span>
-                  <div onclick="ord.reaction.removeSlowly(this, '.temperature_measurement');" class="remove">remove</div>
+                  <div onclick="ord.utils.removeSlowly(this, '.temperature_measurement');" class="remove">remove</div>
                 </legend>
                 <table class="message">
                   <tr><td>type</td><td><div class="temperature_measurement_type selector" data-proto="TemperatureConditions_Measurement_MeasurementType"></div></td></tr>
@@ -473,7 +473,7 @@ limitations under the License.
                 <legend>
                   <span class="collapse"></span>
                   <span class="h4">Measurement</span>
-                  <div onclick="ord.reaction.removeSlowly(this, '.pressure_measurement');" class="remove">remove</div>
+                  <div onclick="ord.utils.removeSlowly(this, '.pressure_measurement');" class="remove">remove</div>
                 </legend>
                 <table class="message">
                   <tr><td>type</td><td><div class="pressure_measurement_type selector" data-proto="PressureConditions_Measurement_MeasurementType"></div></td></tr>
@@ -551,7 +551,7 @@ limitations under the License.
                 <legend>
                   <span class="collapse"></span>
                   <span class="h4">Measurement</span>
-                  <div onclick="ord.reaction.removeSlowly(this, '.electro_measurement');" class="remove">remove</div>
+                  <div onclick="ord.utils.removeSlowly(this, '.electro_measurement');" class="remove">remove</div>
                 </legend>
                 <input type="radio" class="electro_measurement_current" value="current" checked> current
                 <input type="radio" class="electro_measurement_voltage" value="voltage"> voltage
@@ -639,7 +639,7 @@ limitations under the License.
               <legend>
                 <span class="collapse"></span>
                 <span class="h3">Observation</span>
-                <div onclick="ord.reaction.removeSlowly(this, '.observation');" class="remove">remove</div>
+                <div onclick="ord.utils.removeSlowly(this, '.observation');" class="remove">remove</div>
                 <span class="validate" onclick="ord.observations.validateObservation($(this).closest('.observation'))"></span>
               </legend>
               <table class="message">
@@ -668,7 +668,7 @@ limitations under the License.
             <legend>
               <span class="collapse"></span>
               <span class="h3">Workup</span>
-              <div onclick="ord.reaction.removeSlowly(this, '.workup');" class="remove">remove</div>
+              <div onclick="ord.utils.removeSlowly(this, '.workup');" class="remove">remove</div>
               <span class="validate" onclick="ord.workups.validateWorkup($(this).closest('.workup'))"></span>
             </legend>
             <table class="message">
@@ -741,7 +741,7 @@ limitations under the License.
               <legend>
                 <span class="collapse"></span>
                 <span class="h5">Temperature measurement</span>
-                <div onclick="ord.reaction.removeSlowly(this, '.workup_temperature_measurement');" class="remove">remove</div>
+                <div onclick="ord.utils.removeSlowly(this, '.workup_temperature_measurement');" class="remove">remove</div>
               </legend>
               <table class="message">
                 <tr><td>type</td><td><div class="workup_temperature_measurement_type selector" data-proto="TemperatureConditions_Measurement_MeasurementType"></div></td></tr>
@@ -776,7 +776,7 @@ limitations under the License.
             <legend>
               <span class="collapse"></span>
               <span class="h3">Outcome</span>
-              <div onclick="ord.reaction.removeSlowly(this, '.outcome');" class="remove">remove</div>
+              <div onclick="ord.utils.removeSlowly(this, '.outcome');" class="remove">remove</div>
               <span class="validate" onclick="ord.outcomes.validateOutcome($(this).closest('.outcome'))"></span>
             </legend>
             <table class="message">
@@ -809,7 +809,7 @@ limitations under the License.
               <legend>
                 <span class="collapse"></span>
                 <span class="h4">Product</span>
-                <div onclick="ord.reaction.removeSlowly(this, '.outcome_product');" class="remove">remove</div>
+                <div onclick="ord.utils.removeSlowly(this, '.outcome_product');" class="remove">remove</div>
                 <span class="validate" onclick="ord.products.validateProduct($(this).closest('.outcome_product'))"></span>
               </legend>
               <table class="message">
@@ -847,7 +847,7 @@ limitations under the License.
                 <legend>
                   <span class="collapse"></span>
                   <span class="h6">Product Measurement</span>
-                  <div onclick="ord.reaction.removeSlowly(this, '.product_measurement');" class="remove">remove</div>
+                  <div onclick="ord.utils.removeSlowly(this, '.product_measurement');" class="remove">remove</div>
                   <span class="validate" onclick="ord.products.validateMeasurement($(this).closest('.product_measurement'))"></span>
                 </legend>
                 <table class="message product_measurement_value_type">
@@ -988,7 +988,7 @@ limitations under the License.
               <legend>
                 <span class="collapse"></span>
                 <span class="h4">Analysis</span>
-                <div onclick="ord.reaction.removeSlowly(this, '.outcome_analysis');" class="remove">remove</div>
+                <div onclick="ord.utils.removeSlowly(this, '.outcome_analysis');" class="remove">remove</div>
                 <span class="validate" onclick="ord.outcomes.validateAnalysis($(this).closest('.outcome_analysis'))" ></span>
               </legend>
               <table class="message">
@@ -1020,7 +1020,7 @@ limitations under the License.
               <legend>
                 <span class="collapse"></span>
                 <span class="h5">Analytical data</span>
-                <div onclick="ord.reaction.removeSlowly(this, '.outcome_data');" class="remove">remove</div>
+                <div onclick="ord.utils.removeSlowly(this, '.outcome_data');" class="remove">remove</div>
               </legend>
               <table class="message">
                 <tr><td>name</td><td><div class="outcome_data_name edittext"></div></td></tr>
@@ -1084,7 +1084,7 @@ limitations under the License.
               <legend>
                 <span class="collapse"></span>
                 <span class="h3">Record modification</span>
-                <div onclick="ord.reaction.removeSlowly(this, '.provenance_modified');" class="remove">remove</div>
+                <div onclick="ord.utils.removeSlowly(this, '.provenance_modified');" class="remove">remove</div>
                 <span data-toggle="tooltip" data-placement="right" title="Details about subsequent modifications to this reaction record.">
                 <span class="fa fa-question-circle" aria-hidden="true"></span>
               </span>
@@ -1128,8 +1128,8 @@ limitations under the License.
     <span id="validate_template" style="display: none">
       <span class="validate_button" aria-hidden="true">validate</span>
       <span class="validate_status-message">
-        <span onmouseenter="ord.reaction.toggleValidateMessage($(this).closest('.validate'), '.validate_message')" onmouseleave="ord.reaction.toggleValidateMessage($(this).closest('.validate'), '.validate_message')" class="validate_status">unvalidated</span>
-        <span onmouseenter="ord.reaction.toggleValidateMessage($(this).closest('.validate'), '.validate_warning_message')" onmouseleave="ord.reaction.toggleValidateMessage($(this).closest('.validate'), '.validate_warning_message')" class="validate_warning_status fa fa-bell"></span>
+        <span onmouseenter="ord.utils.toggleValidateMessage($(this).closest('.validate'), '.validate_message')" onmouseleave="ord.utils.toggleValidateMessage($(this).closest('.validate'), '.validate_message')" class="validate_status">unvalidated</span>
+        <span onmouseenter="ord.utils.toggleValidateMessage($(this).closest('.validate'), '.validate_warning_message')" onmouseleave="ord.utils.toggleValidateMessage($(this).closest('.validate'), '.validate_warning_message')" class="validate_warning_status fa fa-bell"></span>
         <span class="validate_message"></span>
         <span class="validate_warning_message"></span>
       </span>
@@ -1141,7 +1141,7 @@ limitations under the License.
           <td>value</td>
           <td>
             <div class="reaction_identifier_value edittext longtext"></div>
-            <span class="fa fa-upload text_upload" aria-hidden="true" style="cursor:pointer;" onclick="ord.reaction.setTextFromFile($(this).closest('.reaction_identifier'), 'reaction_identifier_value');"></span>
+            <span class="fa fa-upload text_upload" aria-hidden="true" style="cursor:pointer;" onclick="ord.utils.setTextFromFile($(this).closest('.reaction_identifier'), 'reaction_identifier_value');"></span>
           </td>
         </tr>
         <tr>
@@ -1152,7 +1152,7 @@ limitations under the License.
           <td>details</td>
           <td>
             <div class="reaction_identifier_details edittext"></div>
-            <div class="remove" onclick="ord.reaction.removeSlowly(this, '.reaction_identifier');">remove</div>
+            <div class="remove" onclick="ord.utils.removeSlowly(this, '.reaction_identifier');">remove</div>
           </td>
         </tr>
       </table>
@@ -1186,7 +1186,7 @@ limitations under the License.
       </table>
     </div>
 
-    <div id="undo_template" class="undo" style="display: none;" onclick="ord.reaction.undoSlowly();">undo</div>
+    <div id="undo_template" class="undo" style="display: none;" onclick="ord.utils.undoSlowly();">undo</div>
 
     <script>
         document.body.onload = async function () {

--- a/js/amounts.js
+++ b/js/amounts.js
@@ -22,6 +22,7 @@ exports = {
   unload,
 };
 
+goog.require('ord.utils');
 goog.require('proto.ord.Amount');
 goog.require('proto.ord.Mass');
 goog.require('proto.ord.Moles');
@@ -78,7 +79,7 @@ function load(node, amount) {
       $('.amount_precision', node).text(amount.getMass().getPrecision());
     }
     $('.amount_units_mass', node).show();
-    ord.reaction.setSelector(
+    ord.utils.setSelector(
         $('.amount_units_mass', amountNode), amount.getMass().getUnits());
   } else if (amount.hasMoles()) {
     $('input[value=\'moles\']', amountNode).click();
@@ -89,7 +90,7 @@ function load(node, amount) {
       $('.amount_precision', node).text(amount.getMoles().getPrecision());
     }
     $('.amount_units_moles', node).show();
-    ord.reaction.setSelector(
+    ord.utils.setSelector(
         $('.amount_units_moles', amountNode), amount.getMoles().getUnits());
   } else if (amount.hasVolume()) {
     $('input[value=\'volume\']', amountNode).click();
@@ -104,9 +105,9 @@ function load(node, amount) {
     const solutes = amount.hasVolumeIncludesSolutes() ?
         amount.getVolumeIncludesSolutes() :
         null;
-    ord.reaction.setOptionalBool(
+    ord.utils.setOptionalBool(
         $('.includes_solutes.optional_bool', node), solutes);
-    ord.reaction.setSelector(
+    ord.utils.setSelector(
         $('.amount_units_volume', amountNode), amount.getVolume().getUnits());
   }
 }
@@ -124,14 +125,14 @@ function unload(node) {
   const mass = unloadMass(node);
   const moles = unloadMoles(node);
   const volume = unloadVolume(node);
-  if (!ord.reaction.isEmptyMessage(mass)) {
+  if (!ord.utils.isEmptyMessage(mass)) {
     amount.setMass(mass);
-  } else if (!ord.reaction.isEmptyMessage(moles)) {
+  } else if (!ord.utils.isEmptyMessage(moles)) {
     amount.setMoles(moles);
-  } else if (!ord.reaction.isEmptyMessage(volume)) {
+  } else if (!ord.utils.isEmptyMessage(volume)) {
     amount.setVolume(volume);
-    const solutes = ord.reaction.getOptionalBool(
-        $('.includes_solutes.optional_bool', node));
+    const solutes =
+        ord.utils.getOptionalBool($('.includes_solutes.optional_bool', node));
     amount.setVolumeIncludesSolutes(solutes);
   }
   return amount;
@@ -152,7 +153,7 @@ function unloadMass(node) {
   if (!isNaN(value)) {
     mass.setValue(value);
   }
-  const units = ord.reaction.getSelector($('.amount_units_mass', node));
+  const units = ord.utils.getSelector($('.amount_units_mass', node));
   mass.setUnits(units);
   const precision = parseFloat($('.amount_precision', node).text());
   if (!isNaN(precision)) {
@@ -176,7 +177,7 @@ function unloadMoles(node) {
   if (!isNaN(value)) {
     moles.setValue(value);
   }
-  const units = ord.reaction.getSelector($('.amount_units_moles', node));
+  const units = ord.utils.getSelector($('.amount_units_moles', node));
   moles.setUnits(units);
   const precision = parseFloat($('.amount_precision', node).text());
   if (!isNaN(precision)) {
@@ -200,7 +201,7 @@ function unloadVolume(node) {
   if (!isNaN(value)) {
     volume.setValue(value);
   }
-  const units = ord.reaction.getSelector($('.amount_units_volume', node));
+  const units = ord.utils.getSelector($('.amount_units_volume', node));
   volume.setUnits(units);
   const precision = parseFloat($('.amount_precision', node).text());
   if (!isNaN(precision)) {

--- a/js/codes.js
+++ b/js/codes.js
@@ -23,6 +23,7 @@ exports = {
 };
 
 goog.require('ord.data');
+goog.require('ord.utils');
 goog.require('proto.ord.Data');
 
 /**
@@ -55,7 +56,7 @@ function loadCode(name, code) {
 function unload(codes) {
   $('.setup_code').each(function(index, node) {
     node = $(node);
-    if (!ord.reaction.isTemplateOrUndoBuffer(node)) {
+    if (!ord.utils.isTemplateOrUndoBuffer(node)) {
       unloadCode(codes, node);
     }
   });
@@ -70,7 +71,7 @@ function unload(codes) {
 function unloadCode(codes, node) {
   const name = $('.setup_code_name', node).text();
   const code = ord.data.unloadData(node);
-  if (name || !ord.reaction.isEmptyMessage(code)) {
+  if (name || !ord.utils.isEmptyMessage(code)) {
     codes.set(name, code);
   }
 }
@@ -80,7 +81,7 @@ function unloadCode(codes, node) {
  * @return {!Node} The newly added root node for the automation_code section.
  */
 function addCode() {
-  const node = ord.reaction.addSlowly('#setup_code_template', '#setup_codes');
+  const node = ord.utils.addSlowly('#setup_code_template', '#setup_codes');
   ord.data.addData(node);
   return node;
 }

--- a/js/compounds.js
+++ b/js/compounds.js
@@ -37,6 +37,7 @@ exports = {
 
 goog.require('ord.amounts');
 goog.require('ord.data');
+goog.require('ord.utils');
 goog.require('proto.ord.Compound');
 goog.require('proto.ord.CompoundIdentifier');
 goog.require('proto.ord.Compound.Source');
@@ -72,11 +73,11 @@ function loadCompound(root, compound) {
  */
 function loadIntoCompound(node, compound) {
   const reactionRole = compound.getReactionRole();
-  ord.reaction.setSelector($('.component_reaction_role', node), reactionRole);
+  ord.utils.setSelector($('.component_reaction_role', node), reactionRole);
   $('.component_reaction_role', node).trigger('change');
 
   const isLimiting = compound.hasIsLimiting() ? compound.getIsLimiting() : null;
-  ord.reaction.setOptionalBool($('.component_limiting', node), isLimiting);
+  ord.utils.setOptionalBool($('.component_limiting', node), isLimiting);
 
   const identifiers = compound.getIdentifiersList();
   identifiers.forEach(identifier => loadIdentifier(node, identifier));
@@ -114,7 +115,7 @@ function loadIdentifier(compoundNode, identifier) {
   const node = addIdentifier(compoundNode);
   const value = identifier.getValue();
   $('.component_identifier_value', node).first().text(value);
-  ord.reaction.setSelector(node, identifier.getType());
+  ord.utils.setSelector(node, identifier.getType());
   $('.component_identifier_details', node)
       .first()
       .text(identifier.getDetails());
@@ -128,8 +129,7 @@ function loadIdentifier(compoundNode, identifier) {
  */
 function loadPreparation(node, preparation) {
   const type = preparation.getType();
-  ord.reaction.setSelector(
-      $('.component_compound_preparation_type', node), type);
+  ord.utils.setSelector($('.component_compound_preparation_type', node), type);
   const details = preparation.getDetails();
   $('.component_compound_preparation_details', node).text(details);
   const reaction = preparation.getReactionId();
@@ -162,7 +162,7 @@ function unload(node) {
     if (!compoundNode.attr('id')) {
       // Not a template.
       const compound = unloadCompound(compoundNode);
-      if (!ord.reaction.isEmptyMessage(compound)) {
+      if (!ord.utils.isEmptyMessage(compound)) {
         compounds.push(compound);
       }
     }
@@ -180,24 +180,24 @@ function unloadCompound(node) {
   const compound = new proto.ord.Compound();
 
   const reactionRole =
-      ord.reaction.getSelector($('.component_reaction_role', node));
+      ord.utils.getSelector($('.component_reaction_role', node));
   compound.setReactionRole(reactionRole);
 
   // Only call setIsLimiting if this is a reactant Compound.
-  if (ord.reaction.getSelectorText($('.component_reaction_role', node)[0]) ===
+  if (ord.utils.getSelectorText($('.component_reaction_role', node)[0]) ===
       'REACTANT') {
     const isLimiting =
-        ord.reaction.getOptionalBool($('.component_limiting', node));
+        ord.utils.getOptionalBool($('.component_limiting', node));
     compound.setIsLimiting(isLimiting);
   }
 
   const identifiers = unloadIdentifiers(node);
-  if (identifiers.some(e => !ord.reaction.isEmptyMessage(e))) {
+  if (identifiers.some(e => !ord.utils.isEmptyMessage(e))) {
     compound.setIdentifiersList(identifiers);
   }
 
   const amount = ord.amounts.unload(node);
-  if (!ord.reaction.isEmptyMessage(amount)) {
+  if (!ord.utils.isEmptyMessage(amount)) {
     compound.setAmount(amount);
   }
 
@@ -206,12 +206,12 @@ function unloadCompound(node) {
     const preparation = unloadPreparation(preparationNode);
     preparations.push(preparation);
   });
-  if (preparations.some(e => !ord.reaction.isEmptyMessage(e))) {
+  if (preparations.some(e => !ord.utils.isEmptyMessage(e))) {
     compound.setPreparationsList(preparations);
   }
 
   const source = unloadSource(node);
-  if (!ord.reaction.isEmptyMessage(source)) {
+  if (!ord.utils.isEmptyMessage(source)) {
     compound.setSource(source);
   }
 
@@ -237,9 +237,9 @@ function unloadIdentifiers(node) {
   const identifiers = [];
   $('.component_identifier', node).each(function(index, node) {
     node = $(node);
-    if (!ord.reaction.isTemplateOrUndoBuffer(node)) {
+    if (!ord.utils.isTemplateOrUndoBuffer(node)) {
       const identifier = unloadIdentifier(node);
-      if (!ord.reaction.isEmptyMessage(identifier)) {
+      if (!ord.utils.isEmptyMessage(identifier)) {
         identifiers.push(identifier);
       }
     }
@@ -260,7 +260,7 @@ function unloadIdentifier(node) {
   if (value) {
     identifier.setValue(value);
   }
-  const type = ord.reaction.getSelector(node);
+  const type = ord.utils.getSelector(node);
   identifier.setType(type);
   const details = $('.component_identifier_details', node).text();
   identifier.setDetails(details);
@@ -276,7 +276,7 @@ function unloadIdentifier(node) {
 function unloadPreparation(node) {
   const preparation = new proto.ord.CompoundPreparation();
   const type =
-      ord.reaction.getSelector($('.component_compound_preparation_type', node));
+      ord.utils.getSelector($('.component_compound_preparation_type', node));
   preparation.setType(type);
   const details = $('.component_compound_preparation_details', node).text();
   preparation.setDetails(details);
@@ -310,12 +310,12 @@ function unloadSource(node) {
  */
 function add(root) {
   const node =
-      ord.reaction.addSlowly('#component_template', $('.components', root));
+      ord.utils.addSlowly('#component_template', $('.components', root));
 
   // Connect reaction role selection to limiting reactant field.
   const roleSelector = $('.component_reaction_role', node);
   roleSelector.change(function() {
-    if (ord.reaction.getSelectorText(this) === 'REACTANT') {
+    if (ord.utils.getSelectorText(this) === 'REACTANT') {
       $('.limiting_reactant', node).show();
     } else {
       $('.limiting_reactant', node).hide();
@@ -325,7 +325,7 @@ function add(root) {
   ord.amounts.init(node);
 
   // Add live validation handling.
-  ord.reaction.addChangeHandler(node, () => {
+  ord.utils.addChangeHandler(node, () => {
     validateCompound(node);
   });
 
@@ -340,7 +340,7 @@ function add(root) {
  * @return {!Node} The node of the new compound identifier div.
  */
 function addIdentifier(node) {
-  const identifierNode = ord.reaction.addSlowly(
+  const identifierNode = ord.utils.addSlowly(
       '#component_identifier_template', $('.identifiers', node).first());
 
   const uploadButton = $('.component_identifier_upload', identifierNode);
@@ -412,7 +412,7 @@ function drawIdentifier(node) {
   // First, pack the current Compound into a message.
   const compound = new proto.ord.Compound();
   const identifiers = unloadIdentifiers(node);
-  if (identifiers.some(e => !ord.reaction.isEmptyMessage(e))) {
+  if (identifiers.some(e => !ord.utils.isEmptyMessage(e))) {
     compound.setIdentifiersList(identifiers);
   }
   // Then, try to resolve compound into a MolBlock.
@@ -457,13 +457,13 @@ function drawIdentifier(node) {
     // Check if an existing SMILES/MolBlock identifier exists. If yes, remove.
     $('.component_identifier', node).each(function(index, node) {
       node = $(node);
-      if (!ord.reaction.isTemplateOrUndoBuffer(node)) {
+      if (!ord.utils.isTemplateOrUndoBuffer(node)) {
         const identifier = unloadIdentifier(node);
         if ((identifier.getType() ===
              proto.ord.CompoundIdentifier.IdentifierType.SMILES) ||
             (identifier.getType() ===
              proto.ord.CompoundIdentifier.IdentifierType.MOLBLOCK)) {
-          ord.reaction.removeSlowly(node, '.component_identifier');
+          ord.utils.removeSlowly(node, '.component_identifier');
         }
       }
     });
@@ -502,13 +502,13 @@ function drawIdentifier(node) {
  * @return {!Node} The div corresponding to the new compound preparation.
  */
 function addPreparation(node) {
-  const PreparationNode = ord.reaction.addSlowly(
+  const PreparationNode = ord.utils.addSlowly(
       '#component_preparation_template', $('.preparations', node));
 
   const typeSelector =
       $('.component_compound_preparation_type', PreparationNode);
   typeSelector.change(function() {
-    if (ord.reaction.getSelectorText(this) == 'SYNTHESIZED') {
+    if (ord.utils.getSelectorText(this) == 'SYNTHESIZED') {
       $('.component_compound_preparation_reaction_id', PreparationNode)
           .css('display', 'inline-block');
     } else {
@@ -550,9 +550,9 @@ function renderCompound(node, compound) {
  * @param {?Node} validateNode The div that is used to show the results of
  *     validation (i.e., success or errors).
  */
-function validateCompound(node, validateNode) {
+function validateCompound(node, validateNode = null) {
   const compound = unloadCompound(node);
-  ord.reaction.validate(compound, 'Compound', node, validateNode);
+  ord.utils.validate(compound, 'Compound', node, validateNode);
 
   // Try to resolve compound structural identifiers. This is tied to
   // validation so the same trigger is used and we only have to unload the
@@ -567,7 +567,7 @@ function validateCompound(node, validateNode) {
  */
 function addFeature(node) {
   const featureNode =
-      ord.reaction.addSlowly('#feature_template', $('.features', node));
+      ord.utils.addSlowly('#feature_template', $('.features', node));
   ord.data.addData(featureNode);
   return featureNode;
 }
@@ -591,7 +591,7 @@ function loadFeature(node, name, feature) {
 function unloadFeature(node, featuresMap) {
   const name = $('.feature_name', node).text();
   const data = ord.data.unloadData(node);
-  if (name || !ord.reaction.isEmptyMessage(data)) {
+  if (name || !ord.utils.isEmptyMessage(data)) {
     featuresMap.set(name, data);
   }
 }

--- a/js/compounds.js
+++ b/js/compounds.js
@@ -547,7 +547,7 @@ function renderCompound(node, compound) {
  * display node.
  * @param {!Node} node The div corresponding to the compound that should be
  *     read from the form and validated.
- * @param {?Node} validateNode The div that is used to show the results of
+ * @param {?Node=} validateNode The div that is used to show the results of
  *     validation (i.e., success or errors).
  */
 function validateCompound(node, validateNode = null) {

--- a/js/conditions.js
+++ b/js/conditions.js
@@ -119,7 +119,7 @@ function unload() {
 /**
  * Validates the reaction conditions defined in the form.
  * @param {!Node} node Root node for the reaction conditions.
- * @param {?Node} validateNode Target node for validation results.
+ * @param {?Node=} validateNode Target node for validation results.
  */
 function validateConditions(node, validateNode = null) {
   const condition = unload();

--- a/js/conditions.js
+++ b/js/conditions.js
@@ -28,6 +28,7 @@ goog.require('ord.illumination');
 goog.require('ord.pressure');
 goog.require('ord.stirring');
 goog.require('ord.temperature');
+goog.require('ord.utils');
 goog.require('proto.ord.ReactionConditions');
 
 /**
@@ -60,14 +61,14 @@ function load(conditions) {
     ord.flows.load(flow);
   }
   const reflux = conditions.hasReflux() ? conditions.getReflux() : null;
-  ord.reaction.setOptionalBool($('#condition_reflux'), reflux);
+  ord.utils.setOptionalBool($('#condition_reflux'), reflux);
   if (conditions.hasPh()) {
     $('#condition_ph').text(conditions.getPh());
   }
   const dynamic = conditions.hasConditionsAreDynamic() ?
       conditions.getConditionsAreDynamic() :
       null;
-  ord.reaction.setOptionalBool($('#condition_dynamic'), dynamic);
+  ord.utils.setOptionalBool($('#condition_dynamic'), dynamic);
   $('#condition_details').text(conditions.getDetails());
 }
 
@@ -78,37 +79,37 @@ function load(conditions) {
 function unload() {
   const conditions = new proto.ord.ReactionConditions();
   const temperature = ord.temperature.unload();
-  if (!ord.reaction.isEmptyMessage(temperature)) {
+  if (!ord.utils.isEmptyMessage(temperature)) {
     conditions.setTemperature(temperature);
   }
   const pressure = ord.pressure.unload();
-  if (!ord.reaction.isEmptyMessage(pressure)) {
+  if (!ord.utils.isEmptyMessage(pressure)) {
     conditions.setPressure(pressure);
   }
   const stirring = ord.stirring.unload();
-  if (!ord.reaction.isEmptyMessage(stirring)) {
+  if (!ord.utils.isEmptyMessage(stirring)) {
     conditions.setStirring(stirring);
   }
   const illumination = ord.illumination.unload();
-  if (!ord.reaction.isEmptyMessage(illumination)) {
+  if (!ord.utils.isEmptyMessage(illumination)) {
     conditions.setIllumination(illumination);
   }
   const electro = ord.electro.unload();
-  if (!ord.reaction.isEmptyMessage(electro)) {
+  if (!ord.utils.isEmptyMessage(electro)) {
     conditions.setElectrochemistry(electro);
   }
   const flow = ord.flows.unload();
-  if (!ord.reaction.isEmptyMessage(flow)) {
+  if (!ord.utils.isEmptyMessage(flow)) {
     conditions.setFlow(flow);
   }
 
-  const reflux = ord.reaction.getOptionalBool($('#condition_reflux'));
+  const reflux = ord.utils.getOptionalBool($('#condition_reflux'));
   conditions.setReflux(reflux);
   const ph = parseFloat($('#condition_ph').text());
   if (!isNaN(ph)) {
     conditions.setPh(ph);
   }
-  const dynamic = ord.reaction.getOptionalBool($('#condition_dynamic'));
+  const dynamic = ord.utils.getOptionalBool($('#condition_dynamic'));
   conditions.setConditionsAreDynamic(dynamic);
   const details = $('#condition_details').text();
   conditions.setDetails(details);
@@ -120,7 +121,7 @@ function unload() {
  * @param {!Node} node Root node for the reaction conditions.
  * @param {?Node} validateNode Target node for validation results.
  */
-function validateConditions(node, validateNode) {
+function validateConditions(node, validateNode = null) {
   const condition = unload();
-  ord.reaction.validate(condition, 'ReactionConditions', node, validateNode);
+  ord.utils.validate(condition, 'ReactionConditions', node, validateNode);
 }

--- a/js/crudes.js
+++ b/js/crudes.js
@@ -23,6 +23,7 @@ exports = {
 };
 
 goog.require('ord.amounts');
+goog.require('ord.utils');
 goog.require('proto.ord.CrudeComponent');
 
 /**
@@ -46,11 +47,11 @@ function loadCrude(root, crude) {
   $('.crude_reaction', node).text(reactionId);
 
   const workup = crude.hasIncludesWorkup() ? crude.getIncludesWorkup() : null;
-  ord.reaction.setOptionalBool($('.crude_includes_workup', node), workup);
+  ord.utils.setOptionalBool($('.crude_includes_workup', node), workup);
 
   const derived =
       crude.hasHasDerivedAmount() ? crude.getHasDerivedAmount() : null;
-  ord.reaction.setOptionalBool($('.crude_has_derived', node), derived);
+  ord.utils.setOptionalBool($('.crude_has_derived', node), derived);
 
   const amount = crude.getAmount();
   ord.amounts.load(node, amount);
@@ -68,7 +69,7 @@ function unload(node) {
     if (!crudeNode.attr('id')) {
       // Not a template.
       const crude = unloadCrude(crudeNode);
-      if (!ord.reaction.isEmptyMessage(crude)) {
+      if (!ord.utils.isEmptyMessage(crude)) {
         crudes.push(crude);
       }
     }
@@ -87,15 +88,14 @@ function unloadCrude(node) {
   const reactionId = $('.crude_reaction', node).text();
   crude.setReactionId(reactionId);
 
-  const workup =
-      ord.reaction.getOptionalBool($('.crude_includes_workup', node));
+  const workup = ord.utils.getOptionalBool($('.crude_includes_workup', node));
   crude.setIncludesWorkup(workup);
 
-  const derived = ord.reaction.getOptionalBool($('.crude_has_derived', node));
+  const derived = ord.utils.getOptionalBool($('.crude_has_derived', node));
   crude.setHasDerivedAmount(derived);
 
   const amount = ord.amounts.unload(node);
-  if (!ord.reaction.isEmptyMessage(amount)) {
+  if (!ord.utils.isEmptyMessage(amount)) {
     crude.setAmount(amount);
   }
 
@@ -108,7 +108,7 @@ function unloadCrude(node) {
  * @return {!Node} The newly added root node for the crude component.
  */
 function add(root) {
-  const node = ord.reaction.addSlowly('#crude_template', $('.crudes', root));
+  const node = ord.utils.addSlowly('#crude_template', $('.crudes', root));
   ord.amounts.init(node);
   return node;
 }

--- a/js/data.js
+++ b/js/data.js
@@ -22,6 +22,7 @@ exports = {
   unloadData,
 };
 
+goog.require('ord.utils');
 goog.require('proto.ord.Data');
 
 // Freely create radio button groups by generating new input names.
@@ -34,7 +35,7 @@ let radioGroupCounter = 0;
  */
 function addData(parentNode) {
   const target = parentNode.children('fieldset').first();
-  const node = ord.reaction.addSlowly('#data_template', target);
+  const node = ord.utils.addSlowly('#data_template', target);
   const typeButtons = $('input[type=\'radio\']', node);
   typeButtons.attr('name', 'data_' + radioGroupCounter++);
   typeButtons.change(function() {

--- a/js/dataset.js
+++ b/js/dataset.js
@@ -27,8 +27,8 @@ exports = {
   freeze
 };
 
+goog.require('ord.utils');
 goog.require('proto.ord.Dataset');
-goog.require('ord.reaction');
 
 const session = {
   fileName: null,
@@ -200,7 +200,7 @@ function unloadDataset() {
   const reactionIds = [];
   $('.other_reaction_id').each(function(index, node) {
     node = $(node);
-    if (!ord.reaction.isTemplateOrUndoBuffer(node)) {
+    if (!ord.utils.isTemplateOrUndoBuffer(node)) {
       reactionIds.push($('.other_reaction_id_text', node).text());
     }
   });

--- a/js/electro.js
+++ b/js/electro.js
@@ -194,7 +194,7 @@ function addMeasurement() {
 /**
  * Validates the electrochemistry conditions defined in the form.
  * @param {!Node} node Root node for the electrochemistry conditions.
- * @param {?Node} validateNode Target node for validation results.
+ * @param {?Node=} validateNode Target node for validation results.
  */
 function validateElectro(node, validateNode = null) {
   const electro = unload();

--- a/js/electro.js
+++ b/js/electro.js
@@ -23,6 +23,7 @@ exports = {
   validateElectro
 };
 
+goog.require('ord.utils');
 goog.require('proto.ord.ElectrochemistryConditions');
 goog.require('proto.ord.ElectrochemistryConditions.Measurement');
 
@@ -36,19 +37,19 @@ let radioGroupCounter = 0;
 function load(electro) {
   const type = electro.getElectrochemistryType();
   if (type) {
-    ord.reaction.setSelector($('#electro_type'), type.getType());
+    ord.utils.setSelector($('#electro_type'), type.getType());
     $('#electro_details').text(type.getDetails());
   }
-  ord.reaction.writeMetric('#electro_current', electro.getCurrent());
-  ord.reaction.writeMetric('#electro_voltage', electro.getVoltage());
+  ord.utils.writeMetric('#electro_current', electro.getCurrent());
+  ord.utils.writeMetric('#electro_voltage', electro.getVoltage());
   $('#electro_anode').text(electro.getAnodeMaterial());
   $('#electro_cathode').text(electro.getCathodeMaterial());
-  ord.reaction.writeMetric(
+  ord.utils.writeMetric(
       '#electro_separation', electro.getElectrodeSeparation());
 
   const cell = electro.getCell();
   if (cell) {
-    ord.reaction.setSelector($('#electro_cell_type'), cell.getType());
+    ord.utils.setSelector($('#electro_cell_type'), cell.getType());
     $('#electro_cell_details').text(cell.getDetails());
   }
   electro.getMeasurementsList().forEach(function(measurement) {
@@ -65,19 +66,19 @@ function load(electro) {
 function loadMeasurement(node, measurement) {
   const time = measurement.getTime();
   if (time) {
-    ord.reaction.writeMetric('.electro_measurement_time', time, node);
+    ord.utils.writeMetric('.electro_measurement_time', time, node);
   }
   const current = measurement.getCurrent();
   const voltage = measurement.getVoltage();
   if (current) {
-    ord.reaction.writeMetric('.electro_measurement_current', current, node);
+    ord.utils.writeMetric('.electro_measurement_current', current, node);
     $('input[value=\'current\']', node).prop('checked', true);
     $('.electro_measurement_current_fields', node).show();
     $('.electro_measurement_voltage_fields', node).hide();
   }
   if (voltage) {
     $('input[value=\'voltage\']', node).prop('checked', true);
-    ord.reaction.writeMetric('.electro_measurement_voltage', voltage, node);
+    ord.utils.writeMetric('.electro_measurement_voltage', voltage, node);
     $('.electro_measurement_current_fields', node).hide();
     $('.electro_measurement_voltage_fields', node).show();
   }
@@ -91,43 +92,43 @@ function unload() {
   const electro = new proto.ord.ElectrochemistryConditions();
 
   const type = new proto.ord.ElectrochemistryConditions.ElectrochemistryType();
-  type.setType(ord.reaction.getSelector($('#electro_type')));
+  type.setType(ord.utils.getSelector($('#electro_type')));
   type.setDetails($('#electro_details').text());
-  if (!ord.reaction.isEmptyMessage(type)) {
+  if (!ord.utils.isEmptyMessage(type)) {
     electro.setElectrochemistryType(type);
   }
 
   const current =
-      ord.reaction.readMetric('#electro_current', new proto.ord.Current());
-  if (!ord.reaction.isEmptyMessage(current)) {
+      ord.utils.readMetric('#electro_current', new proto.ord.Current());
+  if (!ord.utils.isEmptyMessage(current)) {
     electro.setCurrent(current);
   }
   const voltage =
-      ord.reaction.readMetric('#electro_voltage', new proto.ord.Voltage());
-  if (!ord.reaction.isEmptyMessage(voltage)) {
+      ord.utils.readMetric('#electro_voltage', new proto.ord.Voltage());
+  if (!ord.utils.isEmptyMessage(voltage)) {
     electro.setVoltage(voltage);
   }
   electro.setAnodeMaterial($('#electro_anode').text());
   electro.setCathodeMaterial($('#electro_cathode').text());
   const electrodeSeparation =
-      ord.reaction.readMetric('#electro_separation', new proto.ord.Length());
-  if (!ord.reaction.isEmptyMessage(electrodeSeparation)) {
+      ord.utils.readMetric('#electro_separation', new proto.ord.Length());
+  if (!ord.utils.isEmptyMessage(electrodeSeparation)) {
     electro.setElectrodeSeparation(electrodeSeparation);
   }
 
   const cell = new proto.ord.ElectrochemistryConditions.ElectrochemistryCell();
-  cell.setType(ord.reaction.getSelector($('#electro_cell_type')));
+  cell.setType(ord.utils.getSelector($('#electro_cell_type')));
   cell.setDetails($('#electro_cell_details').text());
-  if (!ord.reaction.isEmptyMessage(cell)) {
+  if (!ord.utils.isEmptyMessage(cell)) {
     electro.setCell(cell);
   }
 
   const measurements = [];
   $('.electro_measurement').each(function(index, node) {
     node = $(node);
-    if (!ord.reaction.isTemplateOrUndoBuffer(node)) {
+    if (!ord.utils.isTemplateOrUndoBuffer(node)) {
       const measurement = unloadMeasurement(node);
-      if (!ord.reaction.isEmptyMessage(measurement)) {
+      if (!ord.utils.isEmptyMessage(measurement)) {
         measurements.push(measurement);
       }
     }
@@ -143,23 +144,23 @@ function unload() {
  */
 function unloadMeasurement(node) {
   const measurement = new proto.ord.ElectrochemistryConditions.Measurement();
-  const time = ord.reaction.readMetric(
+  const time = ord.utils.readMetric(
       '.electro_measurement_time', new proto.ord.Time(), node);
-  if (!ord.reaction.isEmptyMessage(time)) {
+  if (!ord.utils.isEmptyMessage(time)) {
     measurement.setTime(time);
   }
 
   if ($('.electro_measurement_current', node).is(':checked')) {
-    const current = ord.reaction.readMetric(
+    const current = ord.utils.readMetric(
         '.electro_measurement_current', new proto.ord.Current(), node);
-    if (!ord.reaction.isEmptyMessage(current)) {
+    if (!ord.utils.isEmptyMessage(current)) {
       measurement.setCurrent(current);
     }
   }
   if ($('.electro_measurement_voltage', node).is(':checked')) {
-    const voltage = ord.reaction.readMetric(
+    const voltage = ord.utils.readMetric(
         '.electro_measurement_voltage', new proto.ord.Voltage(), node);
-    if (!ord.reaction.isEmptyMessage(voltage)) {
+    if (!ord.utils.isEmptyMessage(voltage)) {
       measurement.setVoltage(voltage);
     }
   }
@@ -171,7 +172,7 @@ function unloadMeasurement(node) {
  * @return {!Node} The newly added parent node for the measurement.
  */
 function addMeasurement() {
-  const node = ord.reaction.addSlowly(
+  const node = ord.utils.addSlowly(
       '#electro_measurement_template', '#electro_measurements');
 
   const metricButtons = $('input', node);
@@ -195,8 +196,7 @@ function addMeasurement() {
  * @param {!Node} node Root node for the electrochemistry conditions.
  * @param {?Node} validateNode Target node for validation results.
  */
-function validateElectro(node, validateNode) {
+function validateElectro(node, validateNode = null) {
   const electro = unload();
-  ord.reaction.validate(
-      electro, 'ElectrochemistryConditions', node, validateNode);
+  ord.utils.validate(electro, 'ElectrochemistryConditions', node, validateNode);
 }

--- a/js/flow.js
+++ b/js/flow.js
@@ -77,7 +77,7 @@ function unload() {
 /**
  * Validates the flow conditions defined in the form.
  * @param {!Node} node Root node for the flow conditions.
- * @param {?Node} validateNode Target node for validation results.
+ * @param {?Node=} validateNode Target node for validation results.
  */
 function validateFlow(node, validateNode = null) {
   const flow = unload();

--- a/js/flow.js
+++ b/js/flow.js
@@ -22,6 +22,7 @@ exports = {
   validateFlow
 };
 
+goog.require('ord.utils');
 goog.require('proto.ord.FlowConditions');
 goog.require('proto.ord.FlowConditions.Tubing');
 
@@ -32,15 +33,15 @@ goog.require('proto.ord.FlowConditions.Tubing');
 function load(flow) {
   const type = flow.getFlowType();
   if (type) {
-    ord.reaction.setSelector($('#flow_type'), type.getType());
+    ord.utils.setSelector($('#flow_type'), type.getType());
     $('#flow_details').text(type.getDetails());
   }
   $('#flow_pump').text(flow.getPumpType());
 
   const tubing = flow.getTubing();
-  ord.reaction.setSelector($('#flow_tubing_type'), tubing.getType());
+  ord.utils.setSelector($('#flow_tubing_type'), tubing.getType());
   $('#flow_tubing_details').text(tubing.getDetails());
-  ord.reaction.writeMetric('#flow_tubing', tubing.getDiameter());
+  ord.utils.writeMetric('#flow_tubing', tubing.getDiameter());
 }
 
 /**
@@ -51,24 +52,23 @@ function unload() {
   const flow = new proto.ord.FlowConditions();
 
   const type = new proto.ord.FlowConditions.FlowType();
-  type.setType(ord.reaction.getSelector('#flow_type'));
+  type.setType(ord.utils.getSelector('#flow_type'));
   type.setDetails($('#flow_details').text());
-  if (!ord.reaction.isEmptyMessage(type)) {
+  if (!ord.utils.isEmptyMessage(type)) {
     flow.setFlowType(type);
   }
 
   flow.setPumpType($('#flow_pump').text());
 
   const tubing = new proto.ord.FlowConditions.Tubing();
-  tubing.setType(ord.reaction.getSelector('#flow_tubing_type'));
+  tubing.setType(ord.utils.getSelector('#flow_tubing_type'));
   tubing.setDetails($('#flow_tubing_details').text());
-  const diameter =
-      ord.reaction.readMetric('#flow_tubing', new proto.ord.Length());
-  if (!ord.reaction.isEmptyMessage(diameter)) {
+  const diameter = ord.utils.readMetric('#flow_tubing', new proto.ord.Length());
+  if (!ord.utils.isEmptyMessage(diameter)) {
     tubing.setDiameter(diameter);
   }
 
-  if (!ord.reaction.isEmptyMessage(tubing)) {
+  if (!ord.utils.isEmptyMessage(tubing)) {
     flow.setTubing(tubing);
   }
   return flow;
@@ -79,7 +79,7 @@ function unload() {
  * @param {!Node} node Root node for the flow conditions.
  * @param {?Node} validateNode Target node for validation results.
  */
-function validateFlow(node, validateNode) {
+function validateFlow(node, validateNode = null) {
   const flow = unload();
-  ord.reaction.validate(flow, 'FlowConditions', node, validateNode);
+  ord.utils.validate(flow, 'FlowConditions', node, validateNode);
 }

--- a/js/identifiers.js
+++ b/js/identifiers.js
@@ -23,6 +23,7 @@ exports = {
 };
 
 goog.require('ord.uploads');
+goog.require('ord.utils');
 goog.require('proto.ord.ReactionIdentifier');
 
 /**
@@ -44,7 +45,7 @@ function loadIdentifier(identifier) {
   const node = add();
   const value = identifier.getValue();
   $('.reaction_identifier_value', node).text(value);
-  ord.reaction.setSelector(node, identifier.getType());
+  ord.utils.setSelector(node, identifier.getType());
   $('.reaction_identifier_details', node).text(identifier.getDetails());
 }
 
@@ -56,9 +57,9 @@ function unload() {
   const identifiers = [];
   $('.reaction_identifier').each(function(index, node) {
     node = $(node);
-    if (!ord.reaction.isTemplateOrUndoBuffer(node)) {
+    if (!ord.utils.isTemplateOrUndoBuffer(node)) {
       const identifier = unloadIdentifier(node);
-      if (!ord.reaction.isEmptyMessage(identifier)) {
+      if (!ord.utils.isEmptyMessage(identifier)) {
         identifiers.push(identifier);
       }
     }
@@ -79,7 +80,7 @@ function unloadIdentifier(node) {
     identifier.setValue(value);
   }
 
-  const type = ord.reaction.getSelector(node);
+  const type = ord.utils.getSelector(node);
   if (type) {
     identifier.setType(type);
   }
@@ -96,7 +97,7 @@ function unloadIdentifier(node) {
  */
 function add() {
   const node =
-      ord.reaction.addSlowly('#reaction_identifier_template', '#identifiers');
+      ord.utils.addSlowly('#reaction_identifier_template', '#identifiers');
 
   const uploadButton = $('.reaction_identifier_upload', node);
   uploadButton.change(function() {

--- a/js/illumination.js
+++ b/js/illumination.js
@@ -75,7 +75,7 @@ function unload() {
 /**
  * Validates the illumination conditions defined in the form.
  * @param {!Node} node Root node for the illumination conditions.
- * @param {?Node} validateNode Target node for validation results.
+ * @param {?Node=} validateNode Target node for validation results.
  */
 function validateIllumination(node, validateNode = null) {
   const illumination = unload();

--- a/js/illumination.js
+++ b/js/illumination.js
@@ -22,6 +22,7 @@ exports = {
   validateIllumination
 };
 
+goog.require('ord.utils');
 goog.require('proto.ord.IlluminationConditions');
 goog.require('proto.ord.Length');
 goog.require('proto.ord.Wavelength');
@@ -33,14 +34,14 @@ goog.require('proto.ord.Wavelength');
 function load(illumination) {
   const type = illumination.getType();
   if (type) {
-    ord.reaction.setSelector($('#illumination_type'), type.getType());
+    ord.utils.setSelector($('#illumination_type'), type.getType());
     $('#illumination_details').text(type.getDetails());
   }
   const wavelength = illumination.getPeakWavelength();
-  ord.reaction.writeMetric('#illumination_wavelength', wavelength);
+  ord.utils.writeMetric('#illumination_wavelength', wavelength);
   $('#illumination_color').text(illumination.getColor());
   const distance = illumination.getDistanceToVessel();
-  ord.reaction.writeMetric('#illumination_distance', distance);
+  ord.utils.writeMetric('#illumination_distance', distance);
 }
 
 /**
@@ -51,21 +52,21 @@ function unload() {
   const illumination = new proto.ord.IlluminationConditions();
 
   const type = new proto.ord.IlluminationConditions.IlluminationType();
-  type.setType(ord.reaction.getSelector($('#illumination_type')));
+  type.setType(ord.utils.getSelector($('#illumination_type')));
   type.setDetails($('#illumination_details').text());
-  if (!ord.reaction.isEmptyMessage(type)) {
+  if (!ord.utils.isEmptyMessage(type)) {
     illumination.setType(type);
   }
 
-  const wavelength = ord.reaction.readMetric(
+  const wavelength = ord.utils.readMetric(
       '#illumination_wavelength', new proto.ord.Wavelength());
-  if (!ord.reaction.isEmptyMessage(wavelength)) {
+  if (!ord.utils.isEmptyMessage(wavelength)) {
     illumination.setPeakWavelength(wavelength);
   }
   illumination.setColor($('#illumination_color').text());
   const distance =
-      ord.reaction.readMetric('#illumination_distance', new proto.ord.Length());
-  if (!ord.reaction.isEmptyMessage(distance)) {
+      ord.utils.readMetric('#illumination_distance', new proto.ord.Length());
+  if (!ord.utils.isEmptyMessage(distance)) {
     illumination.setDistanceToVessel(distance);
   }
   return illumination;
@@ -76,8 +77,8 @@ function unload() {
  * @param {!Node} node Root node for the illumination conditions.
  * @param {?Node} validateNode Target node for validation results.
  */
-function validateIllumination(node, validateNode) {
+function validateIllumination(node, validateNode = null) {
   const illumination = unload();
-  ord.reaction.validate(
+  ord.utils.validate(
       illumination, 'IlluminationConditions', node, validateNode);
 }

--- a/js/inputs.js
+++ b/js/inputs.js
@@ -24,11 +24,11 @@ exports = {
   add,
   validateInput,
   addInputByString,
-  updateSidebar
 };
 
 goog.require('ord.compounds');
 goog.require('ord.crudes');
+goog.require('ord.utils');
 goog.require('proto.ord.FlowRate');
 goog.require('proto.ord.ReactionInput');
 goog.require('proto.ord.Time');
@@ -43,7 +43,7 @@ function load(inputs) {
     const input = inputs.get(name);
     loadInput('#inputs', name, input);
   });
-  updateSidebar();
+  ord.reaction.updateSidebar();
 }
 
 /**
@@ -113,31 +113,31 @@ function loadInputUnnamed(node, input) {
 
   const additionTime = input.getAdditionTime();
   if (additionTime) {
-    ord.reaction.writeMetric('.input_addition_time', additionTime, node);
+    ord.utils.writeMetric('.input_addition_time', additionTime, node);
   }
   const additionSpeed = input.getAdditionSpeed();
   if (additionSpeed) {
-    ord.reaction.setSelector(
+    ord.utils.setSelector(
         $('.input_addition_speed_type', node), additionSpeed.getType());
     $('.input_addition_speed_details', node).text(additionSpeed.getDetails());
   }
   const additionDevice = input.getAdditionDevice();
   if (additionDevice) {
-    ord.reaction.setSelector(
+    ord.utils.setSelector(
         $('.input_addition_device_type', node), additionDevice.getType());
     $('.input_addition_device_details', node).text(additionDevice.getDetails());
   }
   const duration = input.getAdditionDuration();
   if (duration) {
-    ord.reaction.writeMetric('.input_addition_duration', duration, node);
+    ord.utils.writeMetric('.input_addition_duration', duration, node);
   }
   const temperature = input.getAdditionTemperature();
   if (temperature) {
-    ord.reaction.writeMetric('.input_addition_temperature', temperature, node);
+    ord.utils.writeMetric('.input_addition_temperature', temperature, node);
   }
   const flowRate = input.getFlowRate();
   if (flowRate) {
-    ord.reaction.writeMetric('.input_flow_rate', flowRate, node);
+    ord.utils.writeMetric('.input_flow_rate', flowRate, node);
   }
   return node;
 }
@@ -149,7 +149,7 @@ function loadInputUnnamed(node, input) {
 function unload(inputs) {
   $('#inputs > div.input').each(function(index, node) {
     node = $(node);
-    if (!ord.reaction.isTemplateOrUndoBuffer(node)) {
+    if (!ord.utils.isTemplateOrUndoBuffer(node)) {
       unloadInput(inputs, node);
     }
   });
@@ -163,7 +163,7 @@ function unload(inputs) {
 function unloadInput(inputs, node) {
   const name = $('.input_name', node).text();
   const input = unloadInputUnnamed(node);
-  if (name || !ord.reaction.isEmptyMessage(input)) {
+  if (name || !ord.utils.isEmptyMessage(input)) {
     inputs.set(name, input);
   }
 }
@@ -177,12 +177,12 @@ function unloadInputUnnamed(node) {
   const input = new proto.ord.ReactionInput();
 
   const compounds = ord.compounds.unload(node);
-  if (compounds.some(e => !ord.reaction.isEmptyMessage(e))) {
+  if (compounds.some(e => !ord.utils.isEmptyMessage(e))) {
     input.setComponentsList(compounds);
   }
 
   const crudes = ord.crudes.unload(node);
-  if (crudes.some(e => !ord.reaction.isEmptyMessage(e))) {
+  if (crudes.some(e => !ord.utils.isEmptyMessage(e))) {
     input.setCrudeComponentsList(crudes);
   }
 
@@ -190,43 +190,43 @@ function unloadInputUnnamed(node) {
   if (!isNaN(additionOrder)) {
     input.setAdditionOrder(additionOrder);
   }
-  const additionTime = ord.reaction.readMetric(
-      '.input_addition_time', new proto.ord.Time(), node);
-  if (!ord.reaction.isEmptyMessage(additionTime)) {
+  const additionTime =
+      ord.utils.readMetric('.input_addition_time', new proto.ord.Time(), node);
+  if (!ord.utils.isEmptyMessage(additionTime)) {
     input.setAdditionTime(additionTime);
   }
 
   const additionSpeed = new proto.ord.ReactionInput.AdditionSpeed();
   additionSpeed.setType(
-      ord.reaction.getSelector($('.input_addition_speed_type', node)));
+      ord.utils.getSelector($('.input_addition_speed_type', node)));
   additionSpeed.setDetails($('.input_addition_speed_details', node).text());
-  if (!ord.reaction.isEmptyMessage(additionSpeed)) {
+  if (!ord.utils.isEmptyMessage(additionSpeed)) {
     input.setAdditionSpeed(additionSpeed);
   }
 
   const additionDevice = new proto.ord.ReactionInput.AdditionDevice();
   additionDevice.setType(
-      ord.reaction.getSelector($('.input_addition_device_type', node)));
+      ord.utils.getSelector($('.input_addition_device_type', node)));
   additionDevice.setDetails($('.input_addition_device_details', node).text());
-  if (!ord.reaction.isEmptyMessage(additionDevice)) {
+  if (!ord.utils.isEmptyMessage(additionDevice)) {
     input.setAdditionDevice(additionDevice);
   }
 
-  const additionDuration = ord.reaction.readMetric(
+  const additionDuration = ord.utils.readMetric(
       '.input_addition_duration', new proto.ord.Time(), node);
-  if (!ord.reaction.isEmptyMessage(additionDuration)) {
+  if (!ord.utils.isEmptyMessage(additionDuration)) {
     input.setAdditionDuration(additionDuration);
   }
 
-  const additionTemperature = ord.reaction.readMetric(
+  const additionTemperature = ord.utils.readMetric(
       '.input_addition_temperature', new proto.ord.Temperature(), node);
-  if (!ord.reaction.isEmptyMessage(additionTemperature)) {
+  if (!ord.utils.isEmptyMessage(additionTemperature)) {
     input.setAdditionTemperature(additionTemperature);
   }
 
-  const flowRate = ord.reaction.readMetric(
-      '.input_flow_rate', new proto.ord.FlowRate(), node);
-  if (!ord.reaction.isEmptyMessage(flowRate)) {
+  const flowRate =
+      ord.utils.readMetric('.input_flow_rate', new proto.ord.FlowRate(), node);
+  if (!ord.utils.isEmptyMessage(flowRate)) {
     input.setFlowRate(flowRate);
   }
 
@@ -240,18 +240,18 @@ function unloadInputUnnamed(node) {
  * @return {!Node} The newly added parent node for the reaction input.
  */
 function add(root, classes) {
-  const node = ord.reaction.addSlowly('#input_template', root);
+  const node = ord.utils.addSlowly('#input_template', root);
   if (Array.isArray(classes) && classes.length) {
     node.addClass(classes);
   }
-  updateSidebar();
+  ord.reaction.updateSidebar();
   // Add live validation handling.
-  ord.reaction.addChangeHandler(node, () => {
+  ord.utils.addChangeHandler(node, () => {
     validateInput(node);
   });
   // Update the sidebar when the input name is changed.
   const nameNode = node.find('.input_name').first();
-  nameNode.blur(updateSidebar);
+  nameNode.blur(ord.reaction.updateSidebar);
   return node;
 }
 
@@ -260,38 +260,7 @@ function add(root, classes) {
  * @param {!Node} node Root node for the reaction input.
  * @param {?Node} validateNode Target node for validation results.
  */
-function validateInput(node, validateNode) {
+function validateInput(node, validateNode = null) {
   const input = unloadInputUnnamed(node);
-  ord.reaction.validate(input, 'ReactionInput', node, validateNode);
-}
-
-/**
- * Updates the input entries in the sidebar.
- */
-function updateSidebar() {
-  $('#navInputs').empty();
-  $('.input:visible').not('.workup_input').each(function(index) {
-    const node = $(this);
-    let name = node.find('.input_name').first().text();
-    if (name === '') {
-      name = '(Input #' + (index + 1) + ')';
-    }
-    node.attr('input_name', 'INPUT-' + name);
-    const navNode = $('<div>&#8226; ' + name + '</div>');
-    navNode.addClass('inputNavSection');
-    navNode.attr('input_name', 'INPUT-' + name);
-    $('#navInputs').append(navNode);
-    navNode.click(scrollToInput);
-  });
-  ord.reaction.updateObserver();
-}
-
-/**
- * Scrolls the viewport to the selected input.
- * @param {!Event} event
- */
-function scrollToInput(event) {
-  const section = $(event.target).attr('input_name');
-  const target = $('.input[input_name=\'' + section + '\']');
-  target[0].scrollIntoView({behavior: 'smooth'});
+  ord.utils.validate(input, 'ReactionInput', node, validateNode);
 }

--- a/js/inputs.js
+++ b/js/inputs.js
@@ -43,7 +43,7 @@ function load(inputs) {
     const input = inputs.get(name);
     loadInput('#inputs', name, input);
   });
-  ord.reaction.updateSidebar();
+  ord.utils.updateSidebar();
 }
 
 /**
@@ -244,14 +244,14 @@ function add(root, classes) {
   if (Array.isArray(classes) && classes.length) {
     node.addClass(classes);
   }
-  ord.reaction.updateSidebar();
+  ord.utils.updateSidebar();
   // Add live validation handling.
   ord.utils.addChangeHandler(node, () => {
     validateInput(node);
   });
   // Update the sidebar when the input name is changed.
   const nameNode = node.find('.input_name').first();
-  nameNode.blur(ord.reaction.updateSidebar);
+  nameNode.blur(ord.utils.updateSidebar);
   return node;
 }
 

--- a/js/inputs.js
+++ b/js/inputs.js
@@ -258,7 +258,7 @@ function add(root, classes) {
 /**
  * Validates a reaction input defined in the form.
  * @param {!Node} node Root node for the reaction input.
- * @param {?Node} validateNode Target node for validation results.
+ * @param {?Node=} validateNode Target node for validation results.
  */
 function validateInput(node, validateNode = null) {
   const input = unloadInputUnnamed(node);

--- a/js/notes.js
+++ b/js/notes.js
@@ -78,7 +78,7 @@ function unload() {
 /**
  * Validates the reaction notes defined in the form.
  * @param {!Node} node Root node for the reaction notes.
- * @param {?Node} validateNode Target node for validation results.
+ * @param {?Node=} validateNode Target node for validation results.
  */
 function validateNotes(node, validateNode = null) {
   const notes = unload();

--- a/js/notes.js
+++ b/js/notes.js
@@ -22,6 +22,7 @@ exports = {
   validateNotes
 };
 
+goog.require('ord.utils');
 goog.require('proto.ord.ReactionNotes');
 
 /**
@@ -29,25 +30,25 @@ goog.require('proto.ord.ReactionNotes');
  * @param {!proto.ord.ReactionNotes} notes
  */
 function load(notes) {
-  ord.reaction.setOptionalBool(
+  ord.utils.setOptionalBool(
       $('#notes_heterogeneous'),
       notes.hasIsHeterogeneous() ? notes.getIsHeterogeneous() : null);
-  ord.reaction.setOptionalBool(
+  ord.utils.setOptionalBool(
       $('#notes_precipitate'),
       notes.hasFormsPrecipitate() ? notes.getFormsPrecipitate() : null);
-  ord.reaction.setOptionalBool(
+  ord.utils.setOptionalBool(
       $('#notes_exothermic'),
       notes.hasIsExothermic() ? notes.getIsExothermic() : null);
-  ord.reaction.setOptionalBool(
+  ord.utils.setOptionalBool(
       $('#notes_offgas'), notes.hasOffgasses() ? notes.getOffgasses() : null);
-  ord.reaction.setOptionalBool(
+  ord.utils.setOptionalBool(
       $('#notes_moisture'),
       notes.hasIsSensitiveToMoisture() ? notes.getIsSensitiveToMoisture() :
                                          null);
-  ord.reaction.setOptionalBool(
+  ord.utils.setOptionalBool(
       $('#notes_oxygen'),
       notes.hasIsSensitiveToOxygen() ? notes.getIsSensitiveToOxygen() : null);
-  ord.reaction.setOptionalBool(
+  ord.utils.setOptionalBool(
       $('#notes_light'),
       notes.hasIsSensitiveToLight() ? notes.getIsSensitiveToLight() : null);
   $('#notes_safety').text(notes.getSafetyNotes());
@@ -61,16 +62,14 @@ function load(notes) {
 function unload() {
   const notes = new proto.ord.ReactionNotes();
   notes.setIsHeterogeneous(
-      ord.reaction.getOptionalBool($('#notes_heterogeneous')));
-  notes.setFormsPrecipitate(
-      ord.reaction.getOptionalBool($('#notes_precipitate')));
-  notes.setIsExothermic(ord.reaction.getOptionalBool($('#notes_exothermic')));
-  notes.setOffgasses(ord.reaction.getOptionalBool($('#notes_offgas')));
+      ord.utils.getOptionalBool($('#notes_heterogeneous')));
+  notes.setFormsPrecipitate(ord.utils.getOptionalBool($('#notes_precipitate')));
+  notes.setIsExothermic(ord.utils.getOptionalBool($('#notes_exothermic')));
+  notes.setOffgasses(ord.utils.getOptionalBool($('#notes_offgas')));
   notes.setIsSensitiveToMoisture(
-      ord.reaction.getOptionalBool($('#notes_moisture')));
-  notes.setIsSensitiveToOxygen(
-      ord.reaction.getOptionalBool($('#notes_oxygen')));
-  notes.setIsSensitiveToLight(ord.reaction.getOptionalBool($('#notes_light')));
+      ord.utils.getOptionalBool($('#notes_moisture')));
+  notes.setIsSensitiveToOxygen(ord.utils.getOptionalBool($('#notes_oxygen')));
+  notes.setIsSensitiveToLight(ord.utils.getOptionalBool($('#notes_light')));
   notes.setSafetyNotes($('#notes_safety').text());
   notes.setProcedureDetails($('#notes_details').text());
   return notes;
@@ -81,7 +80,7 @@ function unload() {
  * @param {!Node} node Root node for the reaction notes.
  * @param {?Node} validateNode Target node for validation results.
  */
-function validateNotes(node, validateNode) {
+function validateNotes(node, validateNode = null) {
   const notes = unload();
-  ord.reaction.validate(notes, 'ReactionNotes', node, validateNode);
+  ord.utils.validate(notes, 'ReactionNotes', node, validateNode);
 }

--- a/js/observations.js
+++ b/js/observations.js
@@ -24,6 +24,7 @@ exports = {
 };
 
 goog.require('ord.data');
+goog.require('ord.utils');
 goog.require('proto.ord.ReactionObservation');
 
 /**
@@ -40,7 +41,7 @@ function load(observations) {
  */
 function loadObservation(observation) {
   const node = add();
-  ord.reaction.writeMetric('.observation_time', observation.getTime(), node);
+  ord.utils.writeMetric('.observation_time', observation.getTime(), node);
   $('.observation_comment', node).text(observation.getComment());
   ord.data.loadData(node, observation.getImage());
 }
@@ -53,9 +54,9 @@ function unload() {
   const observations = [];
   $('.observation').each(function(index, node) {
     node = $(node);
-    if (!ord.reaction.isTemplateOrUndoBuffer(node)) {
+    if (!ord.utils.isTemplateOrUndoBuffer(node)) {
       const observation = unloadObservation(node);
-      if (!ord.reaction.isEmptyMessage(observation)) {
+      if (!ord.utils.isEmptyMessage(observation)) {
         observations.push(observation);
       }
     }
@@ -71,13 +72,13 @@ function unload() {
 function unloadObservation(node) {
   const observation = new proto.ord.ReactionObservation();
   const time =
-      ord.reaction.readMetric('.observation_time', new proto.ord.Time(), node);
-  if (!ord.reaction.isEmptyMessage(time)) {
+      ord.utils.readMetric('.observation_time', new proto.ord.Time(), node);
+  if (!ord.utils.isEmptyMessage(time)) {
     observation.setTime(time);
   }
   observation.setComment($('.observation_comment', node).text());
   const image = ord.data.unloadData(node);
-  if (!ord.reaction.isEmptyMessage(image)) {
+  if (!ord.utils.isEmptyMessage(image)) {
     observation.setImage(image);
   }
   return observation;
@@ -88,10 +89,10 @@ function unloadObservation(node) {
  * @return {!Node} The newly added parent node for the reaction observation.
  */
 function add() {
-  const node = ord.reaction.addSlowly('#observation_template', '#observations');
+  const node = ord.utils.addSlowly('#observation_template', '#observations');
   ord.data.addData(node);
   // Add live validation handling.
-  ord.reaction.addChangeHandler(node, () => {
+  ord.utils.addChangeHandler(node, () => {
     validateObservation(node);
   });
   return node;
@@ -102,7 +103,7 @@ function add() {
  * @param {!Node} node Root node for the reaction observation.
  * @param {?Node} validateNode Target node for validation results.
  */
-function validateObservation(node, validateNode) {
+function validateObservation(node, validateNode = null) {
   const observation = unloadObservation(node);
-  ord.reaction.validate(observation, 'ReactionObservation', node, validateNode);
+  ord.utils.validate(observation, 'ReactionObservation', node, validateNode);
 }

--- a/js/observations.js
+++ b/js/observations.js
@@ -101,7 +101,7 @@ function add() {
 /**
  * Validates a single reaction observation defined in the form.
  * @param {!Node} node Root node for the reaction observation.
- * @param {?Node} validateNode Target node for validation results.
+ * @param {?Node=} validateNode Target node for validation results.
  */
 function validateObservation(node, validateNode = null) {
   const observation = unloadObservation(node);

--- a/js/outcomes.js
+++ b/js/outcomes.js
@@ -28,6 +28,7 @@ exports = {
 
 goog.require('ord.data');
 goog.require('ord.products');
+goog.require('ord.utils');
 goog.require('proto.ord.ReactionOutcome');
 
 // Freely create radio button groups by generating new input names.
@@ -50,12 +51,11 @@ function loadOutcome(outcome) {
 
   const time = outcome.getReactionTime();
   if (time != null) {
-    ord.reaction.writeMetric('.outcome_time', time, node);
+    ord.utils.writeMetric('.outcome_time', time, node);
   }
   const conversion = outcome.getConversion();
   if (conversion) {
-    ord.reaction.writeMetric(
-        '.outcome_conversion', outcome.getConversion(), node);
+    ord.utils.writeMetric('.outcome_conversion', outcome.getConversion(), node);
   }
 
   const analyses = outcome.getAnalysesMap();
@@ -80,8 +80,7 @@ function loadAnalysis(outcomeNode, name, analysis) {
 
   $('.outcome_analysis_name', node).text(name).trigger('input');
 
-  ord.reaction.setSelector(
-      $('.outcome_analysis_type', node), analysis.getType());
+  ord.utils.setSelector($('.outcome_analysis_type', node), analysis.getType());
   const chmoId = analysis.getChmoId();
   if (chmoId != 0) {
     $('.outcome_analysis_chmo_id', node).text(analysis.getChmoId());
@@ -102,7 +101,7 @@ function loadAnalysis(outcomeNode, name, analysis) {
   if (calibrated) {
     $('.outcome_analysis_calibrated', node).text(calibrated.getValue());
   }
-  ord.reaction.setOptionalBool(
+  ord.utils.setOptionalBool(
       $('.outcome_analysis_is_of_isolated_species', node),
       analysis.hasIsOfIsolatedSpecies() ? analysis.getIsOfIsolatedSpecies() :
                                           null);
@@ -127,9 +126,9 @@ function unload() {
   const outcomes = [];
   $('.outcome').each(function(index, node) {
     node = $(node);
-    if (!ord.reaction.isTemplateOrUndoBuffer(node)) {
+    if (!ord.utils.isTemplateOrUndoBuffer(node)) {
       const outcome = unloadOutcome(node);
-      if (!ord.reaction.isEmptyMessage(outcome)) {
+      if (!ord.utils.isEmptyMessage(outcome)) {
         outcomes.push(outcome);
       }
     }
@@ -146,14 +145,14 @@ function unloadOutcome(node) {
   const outcome = new proto.ord.ReactionOutcome();
 
   const time =
-      ord.reaction.readMetric('.outcome_time', new proto.ord.Time(), node);
-  if (!ord.reaction.isEmptyMessage(time)) {
+      ord.utils.readMetric('.outcome_time', new proto.ord.Time(), node);
+  if (!ord.utils.isEmptyMessage(time)) {
     outcome.setReactionTime(time);
   }
 
-  const conversion = ord.reaction.readMetric(
+  const conversion = ord.utils.readMetric(
       '.outcome_conversion', new proto.ord.Percentage(), node);
-  if (!ord.reaction.isEmptyMessage(conversion)) {
+  if (!ord.utils.isEmptyMessage(conversion)) {
     outcome.setConversion(conversion);
   }
 
@@ -163,7 +162,7 @@ function unloadOutcome(node) {
   const analyses = outcome.getAnalysesMap();
   $('.outcome_analysis', node).each(function(index, node) {
     node = $(node);
-    if (!ord.reaction.isTemplateOrUndoBuffer(node)) {
+    if (!ord.utils.isTemplateOrUndoBuffer(node)) {
       unloadAnalysis(node, analyses);
     }
   });
@@ -178,7 +177,7 @@ function unloadOutcome(node) {
 function unloadAnalysisSingle(analysisNode) {
   const analysis = new proto.ord.Analysis();
   analysis.setType(
-      ord.reaction.getSelector($('.outcome_analysis_type', analysisNode)));
+      ord.utils.getSelector($('.outcome_analysis_type', analysisNode)));
   const chmoId = $('.outcome_analysis_chmo_id', analysisNode).text();
   if (!isNaN(chmoId)) {
     analysis.setChmoId(chmoId);
@@ -196,10 +195,10 @@ function unloadAnalysisSingle(analysisNode) {
       $('.outcome_analysis_manufacturer', analysisNode).text());
   const calibrated = new proto.ord.DateTime();
   calibrated.setValue($('.outcome_analysis_calibrated', analysisNode).text());
-  if (!ord.reaction.isEmptyMessage(calibrated)) {
+  if (!ord.utils.isEmptyMessage(calibrated)) {
     analysis.setInstrumentLastCalibrated(calibrated);
   }
-  analysis.setIsOfIsolatedSpecies(ord.reaction.getOptionalBool(
+  analysis.setIsOfIsolatedSpecies(ord.utils.getOptionalBool(
       $('.outcome_analysis_is_of_isolated_species', analysisNode)));
 
   return analysis;
@@ -213,7 +212,7 @@ function unloadAnalysisSingle(analysisNode) {
 function unloadAnalysis(analysisNode, analyses) {
   const analysis = unloadAnalysisSingle(analysisNode);
   const name = $('.outcome_analysis_name', analysisNode).text();
-  if (name || !ord.reaction.isEmptyMessage(analysis)) {
+  if (name || !ord.utils.isEmptyMessage(analysis)) {
     analyses.set(name, analysis);
   }
 }
@@ -226,7 +225,7 @@ function unloadAnalysis(analysisNode, analyses) {
 function unloadData(node, dataMap) {
   const name = $('.outcome_data_name', node).text();
   const data = ord.data.unloadData(node);
-  if (name || !ord.reaction.isEmptyMessage(data)) {
+  if (name || !ord.utils.isEmptyMessage(data)) {
     dataMap.set(name, data);
   }
 }
@@ -236,9 +235,9 @@ function unloadData(node, dataMap) {
  * @return {!Node} The newly added parent node for the reaction outcome.
  */
 function add() {
-  const node = ord.reaction.addSlowly('#outcome_template', '#outcomes');
+  const node = ord.utils.addSlowly('#outcome_template', '#outcomes');
   // Add live validation handling.
-  ord.reaction.addChangeHandler(node, () => {
+  ord.utils.addChangeHandler(node, () => {
     validateOutcome(node);
   });
   return node;
@@ -250,7 +249,7 @@ function add() {
  * @return {!Node} The newly added parent node for the reaction analysis.
  */
 function addAnalysis(node) {
-  const analysisNode = ord.reaction.addSlowly(
+  const analysisNode = ord.utils.addSlowly(
       '#outcome_analysis_template', $('.outcome_analyses', node));
 
   // Handle name changes.
@@ -283,7 +282,7 @@ function addAnalysis(node) {
   });
 
   // Add live validation handling.
-  ord.reaction.addChangeHandler(analysisNode, () => {
+  ord.utils.addChangeHandler(analysisNode, () => {
     validateAnalysis(analysisNode);
   });
   return analysisNode;
@@ -295,7 +294,7 @@ function addAnalysis(node) {
  * @return {!Node} The newly added parent node for the Data record.
  */
 function addData(node) {
-  const processNode = ord.reaction.addSlowly(
+  const processNode = ord.utils.addSlowly(
       '#outcome_data_template', $('.outcome_data_repeated', node));
   ord.data.addData(processNode);
   return processNode;
@@ -306,9 +305,9 @@ function addData(node) {
  * @param {!Node} node Root node for the reaction outcome.
  * @param {?Node} validateNode The target node for validation results.
  */
-function validateOutcome(node, validateNode) {
+function validateOutcome(node, validateNode = null) {
   const outcome = unloadOutcome(node);
-  ord.reaction.validate(outcome, 'ReactionOutcome', node, validateNode);
+  ord.utils.validate(outcome, 'ReactionOutcome', node, validateNode);
 }
 
 /**
@@ -316,7 +315,7 @@ function validateOutcome(node, validateNode) {
  * @param {!Node} node Root node for the reaction analysis.
  * @param {?Node} validateNode The target node for validation results.
  */
-function validateAnalysis(node, validateNode) {
+function validateAnalysis(node, validateNode = null) {
   const analysis = unloadAnalysisSingle(node);
-  ord.reaction.validate(analysis, 'Analysis', node, validateNode);
+  ord.utils.validate(analysis, 'Analysis', node, validateNode);
 }

--- a/js/outcomes.js
+++ b/js/outcomes.js
@@ -303,7 +303,7 @@ function addData(node) {
 /**
  * Validates a reaction outcome defined in the form.
  * @param {!Node} node Root node for the reaction outcome.
- * @param {?Node} validateNode The target node for validation results.
+ * @param {?Node=} validateNode The target node for validation results.
  */
 function validateOutcome(node, validateNode = null) {
   const outcome = unloadOutcome(node);
@@ -313,7 +313,7 @@ function validateOutcome(node, validateNode = null) {
 /**
  * Validates a reaction analysis defined in the form.
  * @param {!Node} node Root node for the reaction analysis.
- * @param {?Node} validateNode The target node for validation results.
+ * @param {?Node=} validateNode The target node for validation results.
  */
 function validateAnalysis(node, validateNode = null) {
   const analysis = unloadAnalysisSingle(node);

--- a/js/pressure.js
+++ b/js/pressure.js
@@ -150,7 +150,7 @@ function addMeasurement() {
 /**
  * Validates pressure conditions defined in the form.
  * @param {!Node} node The node containing the pressure conditions div.
- * @param {?Node} validateNode The target div for validation results.
+ * @param {?Node=} validateNode The target div for validation results.
  */
 function validatePressure(node, validateNode = null) {
   const pressure = unload();

--- a/js/pressure.js
+++ b/js/pressure.js
@@ -23,6 +23,7 @@ exports = {
   validatePressure
 };
 
+goog.require('ord.utils');
 goog.require('proto.ord.Pressure');
 goog.require('proto.ord.PressureConditions');
 goog.require('proto.ord.PressureConditions.Measurement');
@@ -35,7 +36,7 @@ goog.require('proto.ord.Time');
 function load(pressure) {
   const control = pressure.getControl();
   if (control) {
-    ord.reaction.setSelector($('#pressure_control_type'), control.getType());
+    ord.utils.setSelector($('#pressure_control_type'), control.getType());
     $('#pressure_control_details').text(control.getDetails());
   }
   const measurements = pressure.getMeasurementsList();
@@ -44,12 +45,11 @@ function load(pressure) {
     loadMeasurement(measurement, node);
   });
   const setpoint = pressure.getSetpoint();
-  ord.reaction.writeMetric('#pressure_setpoint', setpoint);
+  ord.utils.writeMetric('#pressure_setpoint', setpoint);
 
   const atmosphere = pressure.getAtmosphere();
   if (atmosphere) {
-    ord.reaction.setSelector(
-        $('#pressure_atmosphere_type'), atmosphere.getType());
+    ord.utils.setSelector($('#pressure_atmosphere_type'), atmosphere.getType());
     $('#pressure_atmosphere_details').text(atmosphere.getDetails());
   }
 }
@@ -61,14 +61,14 @@ function load(pressure) {
  */
 function loadMeasurement(measurement, node) {
   const type = measurement.getType();
-  ord.reaction.setSelector($('.pressure_measurement_type', node), type);
+  ord.utils.setSelector($('.pressure_measurement_type', node), type);
   $('.pressure_measurement_details', node).text(measurement.getDetails());
 
   const pressure = measurement.getPressure();
-  ord.reaction.writeMetric('.pressure_measurement_pressure', pressure, node);
+  ord.utils.writeMetric('.pressure_measurement_pressure', pressure, node);
 
   const time = measurement.getTime();
-  ord.reaction.writeMetric('.pressure_measurement_time', time, node);
+  ord.utils.writeMetric('.pressure_measurement_time', time, node);
 }
 
 /**
@@ -79,31 +79,31 @@ function unload() {
   const pressure = new proto.ord.PressureConditions();
 
   const control = new proto.ord.PressureConditions.PressureControl();
-  control.setType(ord.reaction.getSelector($('#pressure_control_type')));
+  control.setType(ord.utils.getSelector($('#pressure_control_type')));
   control.setDetails($('#pressure_control_details').text());
-  if (!ord.reaction.isEmptyMessage(control)) {
+  if (!ord.utils.isEmptyMessage(control)) {
     pressure.setControl(control);
   }
 
   const setpoint =
-      ord.reaction.readMetric('#pressure_setpoint', new proto.ord.Pressure());
-  if (!ord.reaction.isEmptyMessage(setpoint)) {
+      ord.utils.readMetric('#pressure_setpoint', new proto.ord.Pressure());
+  if (!ord.utils.isEmptyMessage(setpoint)) {
     pressure.setSetpoint(setpoint);
   }
 
   const atmosphere = new proto.ord.PressureConditions.Atmosphere();
-  atmosphere.setType(ord.reaction.getSelector('#pressure_atmosphere_type'));
+  atmosphere.setType(ord.utils.getSelector('#pressure_atmosphere_type'));
   atmosphere.setDetails($('#pressure_atmosphere_details').text());
-  if (!ord.reaction.isEmptyMessage(atmosphere)) {
+  if (!ord.utils.isEmptyMessage(atmosphere)) {
     pressure.setAtmosphere(atmosphere);
   }
 
   const measurements = [];
   $('.pressure_measurement').each(function(index, node) {
     node = $(node);
-    if (!ord.reaction.isTemplateOrUndoBuffer(node)) {
+    if (!ord.utils.isTemplateOrUndoBuffer(node)) {
       const measurement = unloadMeasurement(node);
-      if (!ord.reaction.isEmptyMessage(measurement)) {
+      if (!ord.utils.isEmptyMessage(measurement)) {
         measurements.push(measurement);
       }
     }
@@ -120,18 +120,18 @@ function unload() {
  */
 function unloadMeasurement(node) {
   const measurement = new proto.ord.PressureConditions.Measurement();
-  const type = ord.reaction.getSelector($('.pressure_measurement_type', node));
+  const type = ord.utils.getSelector($('.pressure_measurement_type', node));
   measurement.setType(type);
   const details = $('.pressure_measurement_details', node).text();
   measurement.setDetails(details);
-  const pressure = ord.reaction.readMetric(
+  const pressure = ord.utils.readMetric(
       '.pressure_measurement_pressure', new proto.ord.Pressure(), node);
-  if (!ord.reaction.isEmptyMessage(pressure)) {
+  if (!ord.utils.isEmptyMessage(pressure)) {
     measurement.setPressure(pressure);
   }
-  const time = ord.reaction.readMetric(
+  const time = ord.utils.readMetric(
       '.pressure_measurement_time', new proto.ord.Time(), node);
-  if (!ord.reaction.isEmptyMessage(time)) {
+  if (!ord.utils.isEmptyMessage(time)) {
     measurement.setTime(time);
   }
 
@@ -143,7 +143,7 @@ function unloadMeasurement(node) {
  * @return {!Node} The node of the new measurement div.
  */
 function addMeasurement() {
-  return ord.reaction.addSlowly(
+  return ord.utils.addSlowly(
       '#pressure_measurement_template', '#pressure_measurements');
 }
 
@@ -152,7 +152,7 @@ function addMeasurement() {
  * @param {!Node} node The node containing the pressure conditions div.
  * @param {?Node} validateNode The target div for validation results.
  */
-function validatePressure(node, validateNode) {
+function validatePressure(node, validateNode = null) {
   const pressure = unload();
-  ord.reaction.validate(pressure, 'PressureConditions', node, validateNode);
+  ord.utils.validate(pressure, 'PressureConditions', node, validateNode);
 }

--- a/js/products.js
+++ b/js/products.js
@@ -27,6 +27,7 @@ exports = {
 
 goog.require('ord.amounts');
 goog.require('ord.compounds');
+goog.require('ord.utils');
 goog.require('proto.ord.FloatValue');
 goog.require('proto.ord.Percentage');
 goog.require('proto.ord.ProductMeasurement');
@@ -53,14 +54,14 @@ function loadProduct(outcomeNode, product) {
   const node = add(outcomeNode);
 
   const reactionRole = product.getReactionRole();
-  ord.reaction.setSelector($('.component_reaction_role', node), reactionRole);
+  ord.utils.setSelector($('.component_reaction_role', node), reactionRole);
 
   const identifiers = product.getIdentifiersList();
   identifiers.forEach(identifier => {
     ord.compounds.loadIdentifier(node, identifier);
   });
 
-  ord.reaction.setOptionalBool(
+  ord.utils.setOptionalBool(
       $('.outcome_product_desired', node),
       product.hasIsDesiredProduct() ? product.getIsDesiredProduct() : null);
   product.getMeasurementsList().forEach(
@@ -68,7 +69,7 @@ function loadProduct(outcomeNode, product) {
   $('.outcome_product_color', node).text(product.getIsolatedColor());
   const texture = product.getTexture();
   if (texture) {
-    ord.reaction.setSelector(
+    ord.utils.setSelector(
         $('.outcome_product_texture_type', node), texture.getType());
     $('.outcome_product_texture_details', node).text(texture.getDetails());
   }
@@ -93,7 +94,7 @@ function unload(node) {
     if (!productNode.attr('id')) {
       // Not a template.
       const product = unloadProduct(productNode);
-      if (!ord.reaction.isEmptyMessage(product)) {
+      if (!ord.utils.isEmptyMessage(product)) {
         products.push(product);
       }
     }
@@ -110,18 +111,18 @@ function unloadProduct(node) {
   const product = new proto.ord.ProductCompound();
 
   const reactionRole =
-      ord.reaction.getSelector($('.component_reaction_role', node));
+      ord.utils.getSelector($('.component_reaction_role', node));
   product.setReactionRole(reactionRole);
 
   const identifiers =
       ord.compounds.unloadIdentifiers($('.product_compound_identifiers', node));
 
-  if (identifiers.some(e => !ord.reaction.isEmptyMessage(e))) {
+  if (identifiers.some(e => !ord.utils.isEmptyMessage(e))) {
     product.setIdentifiersList(identifiers);
   }
 
   product.setIsDesiredProduct(
-      ord.reaction.getOptionalBool($('.outcome_product_desired', node)));
+      ord.utils.getOptionalBool($('.outcome_product_desired', node)));
 
   const measurements = [];
   $('.product_measurement', node).each(function(index, measurementNode) {
@@ -129,7 +130,7 @@ function unloadProduct(node) {
     if (!measurementNode.attr('id')) {
       // Not a template.
       const measurement = unloadMeasurement(measurementNode);
-      if (!ord.reaction.isEmptyMessage(measurement)) {
+      if (!ord.utils.isEmptyMessage(measurement)) {
         measurements.push(measurement);
       }
     }
@@ -141,9 +142,9 @@ function unloadProduct(node) {
 
   const texture = new proto.ord.ProductCompound.Texture();
   texture.setType(
-      ord.reaction.getSelector($('.outcome_product_texture_type', node)));
+      ord.utils.getSelector($('.outcome_product_texture_type', node)));
   texture.setDetails($('.outcome_product_texture_details', node).text());
-  if (!ord.reaction.isEmptyMessage(texture)) {
+  if (!ord.utils.isEmptyMessage(texture)) {
     product.setTexture(texture);
   }
 
@@ -185,14 +186,14 @@ function unloadAnalysisKeys(node, tag) {
  * @return {!Node} The newly created node.
  */
 function add(node) {
-  const productNode = ord.reaction.addSlowly(
+  const productNode = ord.utils.addSlowly(
       '#outcome_product_template', $('.outcome_products', node));
   ord.amounts.init(node);
 
   // Connect reaction role selection to is_desired_product.
   const roleSelector = $('.component_reaction_role', node);
   roleSelector.change(function() {
-    if (ord.reaction.getSelectorText(this) === 'PRODUCT') {
+    if (ord.utils.getSelectorText(this) === 'PRODUCT') {
       $('.is_desired_product', node).show();
     } else {
       $('.is_desired_product', node).hide();
@@ -201,7 +202,7 @@ function add(node) {
   roleSelector.trigger('change');
 
   // Add live validation handling.
-  ord.reaction.addChangeHandler(productNode, () => {
+  ord.utils.addChangeHandler(productNode, () => {
     validateProduct(productNode);
   });
   return productNode;
@@ -229,7 +230,7 @@ function populateAnalysisSelector(node, analysisSelectorNode) {
  * @return {!Node} The newly created node.
  */
 function addMeasurement(node) {
-  const measurementNode = ord.reaction.addSlowly(
+  const measurementNode = ord.utils.addSlowly(
       '#product_measurement_template',
       $('.product_measurement_repeated', node));
   populateAnalysisSelector(
@@ -267,7 +268,7 @@ function addMeasurement(node) {
   const usesAuthenticStandard =
       $('.product_measurement_uses_authentic_standard', measurementNode);
   usesAuthenticStandard.change(function() {
-    if (ord.reaction.getOptionalBool(usesAuthenticStandard)) {
+    if (ord.utils.getOptionalBool(usesAuthenticStandard)) {
       $('.product_measurement_authentic_standard', measurementNode).show();
     } else {
       $('.product_measurement_authentic_standard', measurementNode).hide();
@@ -276,7 +277,7 @@ function addMeasurement(node) {
   usesAuthenticStandard.trigger('change');
 
   // Add live validation handling.
-  ord.reaction.addChangeHandler(measurementNode, () => {
+  ord.utils.addChangeHandler(measurementNode, () => {
     validateMeasurement(measurementNode);
   });
 
@@ -367,19 +368,19 @@ function addMeasurement(node) {
 function loadMeasurement(productNode, measurement) {
   const node = addMeasurement(productNode);
   $('.analysis_key_selector', node).val(measurement.getAnalysisKey());
-  ord.reaction.setSelector(
+  ord.utils.setSelector(
       $('.product_measurement_type', node), measurement.getType());
   $('.product_measurement_type select', node).trigger('change');
   $('.product_measurement_details', node).text(measurement.getDetails());
-  ord.reaction.setOptionalBool(
+  ord.utils.setOptionalBool(
       $('.product_measurement_uses_internal_standard', node),
       measurement.hasUsesInternalStandard() ?
           measurement.getUsesInternalStandard() :
           null);
-  ord.reaction.setOptionalBool(
+  ord.utils.setOptionalBool(
       $('.product_measurement_is_normalized', node),
       measurement.hasIsNormalized() ? measurement.getIsNormalized() : null);
-  ord.reaction.setOptionalBool(
+  ord.utils.setOptionalBool(
       $('.product_measurement_uses_authentic_standard', node),
       measurement.hasUsesAuthenticStandard() ?
           measurement.getUsesAuthenticStandard() :
@@ -427,20 +428,20 @@ function loadMeasurement(productNode, measurement) {
 
   const retentionTime = measurement.getRetentionTime();
   if (retentionTime) {
-    ord.reaction.writeMetric(
+    ord.utils.writeMetric(
         '.product_measurement_retention_time', retentionTime, node);
   }
 
   const massSpec = measurement.getMassSpecDetails();
   if (massSpec) {
-    ord.reaction.setSelector(
+    ord.utils.setSelector(
         $('.product_measurement_mass_spec_type', node), massSpec.getType());
     $('.product_measurement_mass_spec_details', node)
         .text(massSpec.getDetails());
-    ord.reaction.setOptionalBool(
+    ord.utils.setOptionalBool(
         $('.product_measurement_mass_spec_tic_minimum_mz', node),
         massSpec.hasTicMinimumMz() ? measurement.getTicMinimumMz() : null);
-    ord.reaction.setOptionalBool(
+    ord.utils.setOptionalBool(
         $('.product_measurement_mass_spec_tic_maximum_mz', node),
         massSpec.hasTicMaximumMz() ? measurement.getTicMaximumMz() : null);
     const eicMasses = massSpec.getEicMassesList().join(',');
@@ -449,7 +450,7 @@ function loadMeasurement(productNode, measurement) {
 
   const selectivity = measurement.getSelectivity();
   if (selectivity) {
-    ord.reaction.setSelector(
+    ord.utils.setSelector(
         $('.product_measurement_selectivity_type', node),
         selectivity.getType());
     $('.product_measurement_selectivity_details', node)
@@ -458,8 +459,7 @@ function loadMeasurement(productNode, measurement) {
 
   const wavelength = measurement.getWavelength();
   if (wavelength) {
-    ord.reaction.writeMetric(
-        '.product_measurement_wavelength', wavelength, node);
+    ord.utils.writeMetric('.product_measurement_wavelength', wavelength, node);
   }
 }
 
@@ -475,19 +475,19 @@ function unloadMeasurement(node) {
     measurement.setAnalysisKey(analysisKey);
   }
   measurement.setType(
-      ord.reaction.getSelector($('.product_measurement_type', node)));
+      ord.utils.getSelector($('.product_measurement_type', node)));
   measurement.setDetails($('.product_measurement_details', node).text());
-  measurement.setUsesInternalStandard(ord.reaction.getOptionalBool(
+  measurement.setUsesInternalStandard(ord.utils.getOptionalBool(
       $('.product_measurement_uses_internal_standard', node)));
-  measurement.setIsNormalized(ord.reaction.getOptionalBool(
-      $('.product_measurement_is_normalized', node)));
-  measurement.setUsesAuthenticStandard(ord.reaction.getOptionalBool(
+  measurement.setIsNormalized(
+      ord.utils.getOptionalBool($('.product_measurement_is_normalized', node)));
+  measurement.setUsesAuthenticStandard(ord.utils.getOptionalBool(
       $('.product_measurement_uses_authentic_standard', node)));
 
   const authenticStandardNode =
       $('.product_measurement_authentic_standard', node);
   const compound = ord.compounds.unloadCompound(authenticStandardNode);
-  if (!ord.reaction.isEmptyMessage(compound)) {
+  if (!ord.utils.isEmptyMessage(compound)) {
     measurement.setAuthenticStandard(compound);
   }
 
@@ -502,7 +502,7 @@ function unloadMeasurement(node) {
     if (!isNaN(precision)) {
       percentage.setPrecision(precision);
     }
-    if (!ord.reaction.isEmptyMessage(percentage)) {
+    if (!ord.utils.isEmptyMessage(percentage)) {
       measurement.setPercentage(percentage);
     }
   } else if ($('.product_measurement_float', node).is(':checked')) {
@@ -516,7 +516,7 @@ function unloadMeasurement(node) {
     if (!isNaN(precision)) {
       floatValue.setPrecision(precision);
     }
-    if (!ord.reaction.isEmptyMessage(floatValue)) {
+    if (!ord.utils.isEmptyMessage(floatValue)) {
       measurement.setFloatValue(floatValue);
     }
   } else if ($('.product_measurement_string', node).is(':checked')) {
@@ -527,26 +527,26 @@ function unloadMeasurement(node) {
   } else if ($('.product_measurement_mass', node).is(':checked')) {
     const amount =
         ord.amounts.unload($('.product_measurement_value_type', node));
-    if (!ord.reaction.isEmptyMessage(amount)) {
+    if (!ord.utils.isEmptyMessage(amount)) {
       measurement.setAmount(amount);
     }
   }
 
-  const retentionTime = ord.reaction.readMetric(
+  const retentionTime = ord.utils.readMetric(
       '.product_measurement_retention_time', new proto.ord.Time(), node);
-  if (!ord.reaction.isEmptyMessage(retentionTime)) {
+  if (!ord.utils.isEmptyMessage(retentionTime)) {
     measurement.setRetentionTime(retentionTime);
   }
 
   const massSpecDetails =
       new proto.ord.ProductMeasurement.MassSpecMeasurementDetails();
   massSpecDetails.setType(
-      ord.reaction.getSelector($('.product_measurement_mass_spec_type', node)));
+      ord.utils.getSelector($('.product_measurement_mass_spec_type', node)));
   massSpecDetails.setDetails(
       $('.product_measurement_mass_spec_details', node).text());
-  massSpecDetails.setTicMinimumMz(ord.reaction.getOptionalBool(
+  massSpecDetails.setTicMinimumMz(ord.utils.getOptionalBool(
       $('.product_measurement_mass_spec_tic_minimum_mz', node)));
-  massSpecDetails.setTicMaximumMz(ord.reaction.getOptionalBool(
+  massSpecDetails.setTicMaximumMz(ord.utils.getOptionalBool(
       $('.product_measurement_mass_spec_tic_maximum_mz', node)));
   if ($('.product_measurement_mass_spec_eic_masses', node).text()) {
     const eicMasses = $('.product_measurement_mass_spec_eic_masses', node)
@@ -555,22 +555,22 @@ function unloadMeasurement(node) {
                           .map(parseFloat);
     massSpecDetails.setEicMassesList(eicMasses);
   }
-  if (!ord.reaction.isEmptyMessage(massSpecDetails)) {
+  if (!ord.utils.isEmptyMessage(massSpecDetails)) {
     measurement.setMassSpecDetails(massSpecDetails);
   }
 
   const selectivity = new proto.ord.ProductMeasurement.Selectivity();
-  selectivity.setType(ord.reaction.getSelector(
-      $('.product_measurement_selectivity_type', node)));
+  selectivity.setType(
+      ord.utils.getSelector($('.product_measurement_selectivity_type', node)));
   selectivity.setDetails(
       $('.product_measurement_selectivity_details', node).text());
-  if (!ord.reaction.isEmptyMessage(selectivity)) {
+  if (!ord.utils.isEmptyMessage(selectivity)) {
     measurement.setSelectivity(selectivity);
   }
 
-  const wavelength = ord.reaction.readMetric(
+  const wavelength = ord.utils.readMetric(
       '.product_measurement_wavelength', new proto.ord.Wavelength(), node);
-  if (!ord.reaction.isEmptyMessage(wavelength)) {
+  if (!ord.utils.isEmptyMessage(wavelength)) {
     measurement.setWavelength(wavelength);
   }
   return measurement;
@@ -581,9 +581,9 @@ function unloadMeasurement(node) {
  * @param {!Node} node A node containing a ProductMeasurement.
  * @param {?Node} validateNode The target div for validation results.
  */
-function validateMeasurement(node, validateNode) {
+function validateMeasurement(node, validateNode = null) {
   const measurement = unloadMeasurement(node);
-  ord.reaction.validate(measurement, 'ProductMeasurement', node, validateNode);
+  ord.utils.validate(measurement, 'ProductMeasurement', node, validateNode);
 }
 
 /**
@@ -591,8 +591,8 @@ function validateMeasurement(node, validateNode) {
  * @param {!Node} node A node containing a reaction product.
  * @param {?Node} validateNode The target div for validation results.
  */
-function validateProduct(node, validateNode) {
+function validateProduct(node, validateNode = null) {
   const product = unloadProduct(node);
-  ord.reaction.validate(product, 'ProductCompound', node, validateNode);
+  ord.utils.validate(product, 'ProductCompound', node, validateNode);
   ord.compounds.renderCompound(node, product);
 }

--- a/js/products.js
+++ b/js/products.js
@@ -579,7 +579,7 @@ function unloadMeasurement(node) {
 /**
  * Validates a ProductMeasurement defined in the form.
  * @param {!Node} node A node containing a ProductMeasurement.
- * @param {?Node} validateNode The target div for validation results.
+ * @param {?Node=} validateNode The target div for validation results.
  */
 function validateMeasurement(node, validateNode = null) {
   const measurement = unloadMeasurement(node);
@@ -589,7 +589,7 @@ function validateMeasurement(node, validateNode = null) {
 /**
  * Validates a product defined in the form.
  * @param {!Node} node A node containing a reaction product.
- * @param {?Node} validateNode The target div for validation results.
+ * @param {?Node=} validateNode The target div for validation results.
  */
 function validateProduct(node, validateNode = null) {
   const product = unloadProduct(node);

--- a/js/provenance.js
+++ b/js/provenance.js
@@ -181,7 +181,7 @@ function addModification() {
 /**
  * Validates the reaction provenence defined in the form.
  * @param {!Node} node The node containing reaction provenance information.
- * @param {?Node} validateNode The target div for validation results.
+ * @param {?Node=} validateNode The target div for validation results.
  */
 function validateProvenance(node, validateNode = null) {
   const provenance = unload();

--- a/js/provenance.js
+++ b/js/provenance.js
@@ -23,6 +23,7 @@ exports = {
   validateProvenance
 };
 
+goog.require('ord.utils');
 goog.require('proto.ord.DateTime');
 goog.require('proto.ord.Person');
 goog.require('proto.ord.ReactionProvenance');
@@ -96,7 +97,7 @@ function unload() {
   const provenance = new proto.ord.ReactionProvenance();
 
   const experimenter = unloadPerson($('#provenance_experimenter'));
-  if (!ord.reaction.isEmptyMessage(experimenter)) {
+  if (!ord.utils.isEmptyMessage(experimenter)) {
     provenance.setExperimenter(experimenter);
   }
 
@@ -104,7 +105,7 @@ function unload() {
 
   const start = new proto.ord.DateTime();
   start.setValue($('#provenance_start').text());
-  if (!ord.reaction.isEmptyMessage(start)) {
+  if (!ord.utils.isEmptyMessage(start)) {
     provenance.setExperimentStart(start);
   }
 
@@ -113,7 +114,7 @@ function unload() {
   provenance.setPublicationUrl($('#provenance_url').text());
 
   const created = unloadRecordEvent($('#provenance_created'));
-  if (!ord.reaction.isEmptyMessage(created)) {
+  if (!ord.utils.isEmptyMessage(created)) {
     provenance.setRecordCreated(created);
   }
 
@@ -121,9 +122,9 @@ function unload() {
   $('.provenance_modified', '#provenance_modifieds')
       .each(function(index, node) {
         node = $(node);
-        if (!ord.reaction.isTemplateOrUndoBuffer(node)) {
+        if (!ord.utils.isTemplateOrUndoBuffer(node)) {
           const modified = unloadRecordEvent(node);
-          if (!ord.reaction.isEmptyMessage(modified)) {
+          if (!ord.utils.isEmptyMessage(modified)) {
             modifieds.push(modified);
           }
         }
@@ -141,11 +142,11 @@ function unloadRecordEvent(node) {
   const created = new proto.ord.RecordEvent();
   const createdTime = new proto.ord.DateTime();
   createdTime.setValue($('.provenance_time', node).text());
-  if (!ord.reaction.isEmptyMessage(createdTime)) {
+  if (!ord.utils.isEmptyMessage(createdTime)) {
     created.setTime(createdTime);
   }
   const createdPerson = unloadPerson(node);
-  if (!ord.reaction.isEmptyMessage(createdPerson)) {
+  if (!ord.utils.isEmptyMessage(createdPerson)) {
     created.setPerson(createdPerson);
   }
   const createdDetails = $('.provenance_details', node).text();
@@ -173,7 +174,7 @@ function unloadPerson(node) {
  * @return {!Node} The div containing the new event.
  */
 function addModification() {
-  return ord.reaction.addSlowly(
+  return ord.utils.addSlowly(
       '#provenance_modified_template', '#provenance_modifieds');
 }
 
@@ -182,7 +183,7 @@ function addModification() {
  * @param {!Node} node The node containing reaction provenance information.
  * @param {?Node} validateNode The target div for validation results.
  */
-function validateProvenance(node, validateNode) {
+function validateProvenance(node, validateNode = null) {
   const provenance = unload();
-  ord.reaction.validate(provenance, 'ReactionProvenance', node, validateNode);
+  ord.utils.validate(provenance, 'ReactionProvenance', node, validateNode);
 }

--- a/js/reaction.js
+++ b/js/reaction.js
@@ -17,45 +17,36 @@
 goog.module('ord.reaction');
 goog.module.declareLegacyNamespace();
 exports = {
+  commit,
+  dirty,
+  downloadReaction,
+  freeze,
   initFromDataset,
   initFromReactionId,
-  commit,
-  toggleAutosave,
-  downloadReaction,
-  validateReaction,
-  setTextFromFile,
-  removeSlowly,
-  collapseToggle,
-  addSlowly,
-  addChangeHandler,
-  validate,
-  toggleValidateMessage,
-  compareDataset,
-  unloadReaction,
-  isEmptyMessage,
-  readMetric,
-  writeMetric,
-  setSelector,
-  getSelector,
-  getSelectorText,
-  setOptionalBool,
-  getOptionalBool,
-  freeze,
+  listen,
   setupObserver,
-  updateObserver,
-  undoSlowly,
-  isTemplateOrUndoBuffer
+  toggleAutosave,
+  unloadReaction,
+  updateSidebar,
+  validateReaction,
 };
 
 goog.require('ord.conditions');
-goog.require('ord.enums');
+goog.require('ord.electro');
+goog.require('ord.flows');
 goog.require('ord.identifiers');
+goog.require('ord.illumination');
 goog.require('ord.inputs');
 goog.require('ord.notes');
 goog.require('ord.observations');
 goog.require('ord.outcomes');
+goog.require('ord.pressure');
 goog.require('ord.provenance');
 goog.require('ord.setups');
+goog.require('ord.stirring');
+goog.require('ord.temperature');
+goog.require('ord.uploads');
+goog.require('ord.utils');
 goog.require('ord.workups');
 goog.require('proto.ord.Dataset');
 goog.require('proto.ord.Reaction');
@@ -72,21 +63,19 @@ const session = {
 // Export session, because it's used by test.js.
 exports.session = session;
 
-const FLOAT_PATTERN = /^-?(?:\d+|\d+\.\d*|\d*\.\d+)(?:[eE]-?\d+)?$/;
-const INTEGER_PATTERN = /^-?\d+$/;
-
 /**
  * Initializes the form.
  * @param {!proto.ord.Reaction} reaction Reaction proto to load.
  */
 function init(reaction) {
   // Initialize all the template popup menus.
-  $('.selector').each((index, node) => initSelector($(node)));
-  $('.optional_bool').each((index, node) => initOptionalBool($(node)));
+  $('.selector').each((index, node) => ord.utils.initSelector($(node)));
+  $('.optional_bool')
+      .each((index, node) => ord.utils.initOptionalBool($(node)));
   // Enable all the editable text fields.
   $('.edittext').attr('contentEditable', 'true');
   // Initialize all the validators.
-  $('.validate').each((index, node) => initValidateNode($(node)));
+  $('.validate').each((index, node) => ord.utils.initValidateNode($(node)));
   // Initialize validation handlers that don't go in "add" methods.
   initValidateHandlers();
   // Initailize tooltips.
@@ -102,7 +91,7 @@ function init(reaction) {
   loadReaction(reaction);
   clean();
   // Initialize the collaped/uncollapsed state of the fieldset groups.
-  $('.collapse').each((index, node) => initCollapse($(node)));
+  $('.collapse').each((index, node) => ord.utils.initCollapse($(node)));
   // Trigger reaction-level validation.
   validateReaction();
   // Initialize autosave being on.
@@ -170,10 +159,11 @@ function ready() {
  * @param {!Node} node
  */
 function listen(node) {
-  addChangeHandler($(node), dirty);
-  $('.edittext', node).on('focus', event => selectText(event.target));
-  $('.floattext', node).on('blur', event => checkFloat(event.target));
-  $('.integertext', node).on('blur', event => checkInteger(event.target));
+  ord.utils.addChangeHandler($(node), dirty);
+  $('.edittext', node).on('focus', event => ord.utils.selectText(event.target));
+  $('.floattext', node).on('blur', event => ord.utils.checkFloat(event.target));
+  $('.integertext', node)
+      .on('blur', event => ord.utils.checkInteger(event.target));
 }
 
 /**
@@ -184,8 +174,8 @@ function clickSave() {
   // button visible -- and if ready for a save (not in the process of saving
   // already).
   const saveButton = $('#save');
-  if (saveButton.css('visibility') == 'visible' &&
-      saveButton.text() == 'save') {
+  if (saveButton.css('visibility') === 'visible' &&
+      saveButton.text() === 'save') {
     saveButton.click();
   }
 }
@@ -195,19 +185,20 @@ function clickSave() {
  */
 function toggleAutosave() {
   // We keep track of timers by holding references, only if they're active.
-  if (!session.timers['short']) {
+  const autosave = $('#toggle_autosave');
+  if (!session.timers.short) {
     // Enable a simple timer that saves periodically.
-    session.timers['short'] =
+    session.timers.short =
         setInterval(clickSave, 1000 * 15);  // Save after 15 seconds
-    $('#toggle_autosave').text('autosave: on');
-    $('#toggle_autosave').css('backgroundColor', 'lightgreen');
+    autosave.text('autosave: on');
+    autosave.css('backgroundColor', 'lightgreen');
   } else {
     // Stop the interval timer itself, then remove reference in order to
     // properly later detect that it's stopped.
-    clearInterval(session.timers['short']);
-    session.timers['short'] = null;
-    $('#toggle_autosave').text('autosave: off');
-    $('#toggle_autosave').css('backgroundColor', 'pink');
+    clearInterval(session.timers.short);
+    session.timers.short = null;
+    autosave.text('autosave: off');
+    autosave.css('backgroundColor', 'pink');
   }
 }
 
@@ -222,178 +213,9 @@ function dirty() {
  * Hides the 'save' button.
  */
 function clean() {
-  $('#save').css('visibility', 'hidden');
-  $('#save').text('save');
-}
-
-/**
- * Selects the contents of the given node.
- * @param {!Node} node
- */
-function selectText(node) {
-  const range = document.createRange();
-  range.selectNodeContents(node);
-  const selection = window.getSelection();
-  selection.removeAllRanges();
-  selection.addRange(range);
-}
-
-/**
- * Determines if the text entered in a float input is valid by detecting any
- * characters besides 0-9, a single period to signify a decimal, and a
- * leading hyphen. Also supports scientific notation with either 'e' or 'E'.
- * @param {!Node} node
- */
-function checkFloat(node) {
-  const stringValue = $(node).text().trim();
-  if (stringValue === '') {
-    $(node).removeClass('invalid');
-  } else if (FLOAT_PATTERN.test(stringValue)) {
-    $(node).removeClass('invalid');
-  } else {
-    $(node).addClass('invalid');
-  }
-}
-
-/**
- * Determines if the text entered in an integer input is valid by forbidding
- * any characters besides 0-9 and a leading hyphen.
- * @param {!Node} node
- */
-function checkInteger(node) {
-  const stringValue = $(node).text().trim();
-  if (stringValue === '') {
-    $(node).removeClass('invalid');
-  } else if (INTEGER_PATTERN.test(stringValue)) {
-    $(node).removeClass('invalid');
-  } else {
-    $(node).addClass('invalid');
-  }
-}
-
-/**
- * Prepares a floating point value for display in the form.
- * @param {number} value
- * @return {number}
- */
-function prepareFloat(value) {
-  // Round to N significant digits; this avoid floating point precision issues
-  // that can be quite jarring to users.
-  //
-  // See:
-  //   * https://stackoverflow.com/a/3644302
-  //   * https://medium.com/swlh/ed74c471c1b8
-  //   * https://stackoverflow.com/a/19623253
-  const precision = 7;
-  return parseFloat(value.toPrecision(precision));
-}
-
-/**
- * Adds a jQuery handler to a node such that the handler is run once whenever
- * data entry within that node is changed, *except through remove* -- this must
- * be handled manually. (This prevents inconsistent timing in the ordering of
- * the element being removed and the handler being called.)
- * @param {!Node} node
- * @param {!Function} handler
- */
-function addChangeHandler(node, handler) {
-  // For textboxes
-  node.on('blur', '.edittext', handler);
-  // For selectors, optional bool selectors,
-  // and checkboxes/radio buttons/file upload, respectively
-  node.on('change', '.selector, .optional_bool, input', handler);
-  // For add buttons
-  node.on('click', '.add', handler);
-}
-
-/**
- * Generic validator for many message types, not just reaction.
- * NOTE: This function does not commit or save anything!
- * @param {!jspb.Message} message The proto to validate.
- * @param {string} messageTypeString The message type.
- * @param {!Node} node Parent node for the unloaded message.
- * @param {?Node} validateNode Target div for validation output.
- */
-function validate(message, messageTypeString, node, validateNode) {
-  // eg message is a type of reaction, messageTypeString = 'Reaction'
-  const xhr = new XMLHttpRequest();
-  xhr.open('POST', '/dataset/proto/validate/' + messageTypeString);
-  const binary = message.serializeBinary();
-  if (!validateNode) {
-    validateNode = $('.validate', node).first();
-  }
-  xhr.responseType = 'json';
-  xhr.onload = function() {
-    const validationOutput = xhr.response;
-    const errors = validationOutput.errors;
-    const warnings = validationOutput.warnings;
-    // Add client-side validation errors.
-    $(node).find('.invalid').each(function(index) {
-      const invalidName = $(this).attr('class').split(' ')[0];
-      errors.push('Value for ' + invalidName + ' is invalid');
-    });
-    const statusNode = $('.validate_status', validateNode);
-    const messageNode = $('.validate_message', validateNode);
-    statusNode.removeClass('fa-check');
-    statusNode.removeClass('fa-exclamation-triangle');
-    statusNode.css('backgroundColor', null);
-    statusNode.text('');
-    if (errors.length) {
-      statusNode.addClass('fa fa-exclamation-triangle');
-      statusNode.css('color', 'red');
-      statusNode.text(' ' + errors.length);
-      messageNode.html('<ul></ul>');
-      for (let index = 0; index < errors.length; index++) {
-        const error = errors[index];
-        const errorNode = $('<li></li>');
-        errorNode.text(error);
-        $('ul', messageNode).append(errorNode);
-      }
-      messageNode.css('backgroundColor', 'pink');
-    } else {
-      statusNode.addClass('fa fa-check');
-      statusNode.css('color', 'green');
-      messageNode.html('');
-      messageNode.css('backgroundColor', '');
-      messageNode.css('visibility', 'hidden');
-    }
-    const warningStatusNode = $('.validate_warning_status', validateNode);
-    const warningMessageNode = $('.validate_warning_message', validateNode);
-    if (warnings.length) {
-      warningStatusNode.show();
-      warningStatusNode.text(' ' + warnings.length);
-      warningMessageNode.show();
-      warningMessageNode.html('<ul></ul>');
-      for (let index = 0; index < warnings.length; index++) {
-        const warning = warnings[index];
-        const warningNode = $('<li></li>');
-        warningNode.text(warning);
-        $('ul', warningMessageNode).append(warningNode);
-      }
-    } else {
-      warningStatusNode.hide();
-      warningMessageNode.html('');
-      warningMessageNode.hide();
-    }
-  };
-  xhr.send(binary);
-}
-
-/**
- * Toggles the visibility of the 'validate' button for a given node.
- * @param {!Node} node
- * @param {string} target Destination class for the validation message(s).
- */
-function toggleValidateMessage(node, target) {
-  let messageNode = $(target, node);
-  switch (messageNode.css('visibility')) {
-    case 'visible':
-      messageNode.css('visibility', 'hidden');
-      break;
-    case 'hidden':
-      messageNode.css('visibility', 'visible');
-      break;
-  }
+  const save = $('#save');
+  save.css('visibility', 'hidden');
+  save.text('save');
 }
 
 /**
@@ -419,7 +241,7 @@ function validateReaction() {
   const node = $('#sections');
   const validateNode = $('#reaction_validate');
   const reaction = unloadReaction();
-  validate(reaction, 'Reaction', node, validateNode);
+  ord.utils.validate(reaction, 'Reaction', node, validateNode);
   // Trigger all submessages to validate.
   $('.validate_button:visible:not(#reaction_validate_button)').trigger('click');
   // Render reaction as an HTML block.
@@ -437,7 +259,7 @@ function commit() {
   const reaction = unloadReaction();
   const reactions = session.dataset.getReactionsList();
   reactions[session.index] = reaction;
-  putDataset(session.fileName, session.dataset);
+  ord.utils.putDataset(session.fileName, session.dataset);
   ord.uploads.putAll(session.fileName);
 }
 
@@ -495,29 +317,6 @@ function putDataset(fileName, dataset) {
 }
 
 /**
- * Compares a local Dataset to a Dataset on the server (used for testing).
- * @param {string} fileName The name of a dataset on the server.
- * @param {!proto.ord.Dataset} dataset A local Dataset.
- * @return {!Promise<!Uint8Array>}
- */
-async function compareDataset(fileName, dataset) {
-  return new Promise((resolve, reject) => {
-    const xhr = new XMLHttpRequest();
-    xhr.open('POST', '/dataset/proto/compare/' + fileName);
-    const binary = dataset.serializeBinary();
-    xhr.onload = () => {
-      if (xhr.status == 200) {
-        resolve();
-      } else {
-        reject();
-      }
-    };
-    xhr.onerror = reject;
-    xhr.send(binary);
-  });
-}
-
-/**
  * Adds and populates the form with the given reaction.
  * @param {!proto.ord.Reaction} reaction
  */
@@ -564,10 +363,10 @@ function loadReaction(reaction) {
   $('#reaction_id').text(reaction.getReactionId());
 
   // Clean up floating point entries.
-  $('.floattext').each(function(index) {
+  $('.floattext').each(function() {
     const node = $(this);
     if (node.text() !== '') {
-      node.text(prepareFloat(parseFloat(node.text())));
+      node.text(ord.utils.prepareFloat(parseFloat(node.text())));
     }
   });
 }
@@ -586,17 +385,17 @@ function unloadReaction() {
   ord.inputs.unload(inputs);
 
   const setup = ord.setups.unload();
-  if (!isEmptyMessage(setup)) {
+  if (!ord.utils.isEmptyMessage(setup)) {
     reaction.setSetup(setup);
   }
 
   const conditions = ord.conditions.unload();
-  if (!isEmptyMessage(conditions)) {
+  if (!ord.utils.isEmptyMessage(conditions)) {
     reaction.setConditions(conditions);
   }
 
   const notes = ord.notes.unload();
-  if (!isEmptyMessage(notes)) {
+  if (!ord.utils.isEmptyMessage(notes)) {
     reaction.setNotes(notes);
   }
 
@@ -610,360 +409,13 @@ function unloadReaction() {
   reaction.setOutcomesList(outcomes);
 
   const provenance = ord.provenance.unload();
-  if (!isEmptyMessage(provenance)) {
+  if (!ord.utils.isEmptyMessage(provenance)) {
     reaction.setProvenance(provenance);
   }
 
   // Setter does nothing when passed an empty string.
   reaction.setReactionId($('#reaction_id').text());
   return reaction;
-}
-
-/**
- * Checks if the argument represents an empty protobuf message (that is, the
- * argument's nested arrays only contains null or empty values), or is null or
- * undefined. We use this check on both primitives and arrays/messages.
- * NOTE: Unlike other primitive types, using a setter to set a oneof string
- * field to “” causes the message to include the field and “”, which would be
- * unwanted. So we instead claim that empty strings are empty messages. (Hence
- * we don’t set _any_ empty string.)
- * NOTE: In a submessage, setting a meaningful value (e.g. optional float to 0)
- * will result in a non-null/undefined value in the submessage array. So, if
- * the array of a submessage only contains null and undefined vals, we can
- * assume that the message is truly “empty” (that is, doesn’t have anything
- * meaningful that is set) and can be omitted when constructing the surrounding
- * message.
- * @param {!jspb.Message} obj The object to test.
- * @return {boolean} Whether the message is empty.
- */
-function isEmptyMessage(obj) {
-  const empty = new obj.constructor();
-  // Compare binary encodings to cover optional fields.
-  return JSON.stringify(obj.serializeBinary()) ===
-      JSON.stringify(empty.serializeBinary());
-}
-
-/**
- * Adds an instance of `template` to the root node.
- * @param {string} template A jQuery selector.
- * @param {!Node} root A jQuery object.
- * @return {!Node} The new copy of the template.
- */
-function addSlowly(template, root) {
-  const node = $(template).clone();
-  node.removeAttr('id');
-  $(root).append(node);
-  node.show('slow');
-  dirty();
-  listen(node);
-  $('[data-toggle=\'tooltip\']', node).tooltip();
-  return node;
-}
-
-/**
- * Removes from the DOM the nearest ancestor element matching the pattern.
- * @param {string} button The element from which to start the search.
- * @param {string} pattern The pattern for the element to remove.
- */
-function removeSlowly(button, pattern) {
-  const node = $(button).closest(pattern);
-  // Must call necessary validators only after the node is removed,
-  // but we can only figure out which validators these are before removal.
-  // We do so, and after removal, click the corresponding buttons to trigger
-  // validation.
-  let buttonsToClick = $();
-  node.parents('fieldset').each(function() {
-    buttonsToClick =
-        buttonsToClick.add($(this).children('legend').find('.validate_button'));
-  });
-  makeUndoable(node);
-  node.hide('slow', function() {
-    buttonsToClick.trigger('click');
-    ord.inputs.updateSidebar();
-  });
-  dirty();
-}
-
-/**
- * Reverses the hide() in the most recent invocation of removeSlowly().
- * Removes the node's "undo" button. Does not trigger validation.
- */
-function undoSlowly() {
-  $('.undoable').removeClass('undoable').show('slow');
-  $('.undo').not('#undo_template').hide('slow', function() {
-    $(this).remove();
-    ord.inputs.updateSidebar();
-  });
-  dirty();
-}
-
-/**
- * Marks the given node for possible future undo. Adds an "undo" button to do
- * it. Deletes any preexisting undoable nodes and undo buttons.
- * @param {!Node} node The DOM fragment to hide and re-show.
- */
-function makeUndoable(node) {
-  $('.undoable').remove();
-  node.addClass('undoable');
-  $('.undo').not('#undo_template').remove();
-  const button = $('#undo_template').clone();
-  button.removeAttr('id');
-  node.after(button);
-  button.show('slow');
-}
-
-/**
- * Supports unload() operations by filtering spurious selector matches due
- * either to DOM templates or elements the user has removed undoably.
- * @param {!Node node} node The DOM node to test for spuriousness.
- * @return {boolean} True means ignore this node.
- */
-function isTemplateOrUndoBuffer(node) {
-  return node.attr('id') || node.hasClass('undoable');
-}
-
-/**
- * Toggles the visibility of all siblings of an element, or if a pattern is
- * provided, toggles the visibility of all siblings of the nearest ancestor
- * element matching the pattern.
- * @param {!Node} node The element to toggle or use as the search root.
- * @param {string} pattern The pattern to match for finding siblings to toggle.
- */
-//
-function toggleSlowly(node, pattern) {
-  node = $(node);
-  if (pattern) {
-    node = node.closest(pattern);
-  }
-  // 'collapsed' tag is used to hold previously collapsed siblings,
-  // and would be stored as node's next sibling;
-  // the following line checks whether a collapse has occured.
-  if (node.next('collapsed').length !== 0) {
-    // Need to uncollapse.
-    const collapsedNode = node.next('collapsed');
-    collapsedNode.toggle('slow', () => {
-      collapsedNode.children().unwrap();
-    });
-  } else {
-    // Need to collapse.
-    node.siblings().wrapAll('<collapsed>');
-    node.next('collapsed').toggle('slow');
-  }
-}
-
-/**
- * Toggles the collapse of a section in the form.
- * @param {string} button The element to toggle.
- */
-function collapseToggle(button) {
-  $(button).toggleClass('fa-chevron-down fa-chevron-right');
-  toggleSlowly(button, 'legend');
-}
-
-/**
- * Unpacks a (value, units, precision) tuple into the given type.
- * @param {string} prefix The prefix for element attributes.
- * @param {!jspb.Message} proto A protocol buffer with `value`, `precision`,
- *     and `units` fields.
- * @param {!Node} node The node containing the tuple.
- * @return {!jspb.Message} The updated protocol buffer. Note that the message
- *     is modified in-place.
- */
-function readMetric(prefix, proto, node) {
-  const value = parseFloat($(prefix + '_value', node).text());
-  if (!isNaN(value)) {
-    proto.setValue(value);
-  }
-  if (proto.setUnits) {
-    // proto.ord.Percentage doesn't have units.
-    proto.setUnits(getSelector($(prefix + '_units', node)));
-  }
-  const precision = parseFloat($(prefix + '_precision', node).text());
-  if (!isNaN(precision)) {
-    proto.setPrecision(precision);
-  }
-  return proto;
-}
-
-/**
- * Packs a (value, units, precision) tuple into form elements.
- * @param {string} prefix The prefix for element attributes.
- * @param {!jspb.Message} proto A protocol buffer with `value`, `precision`,
- *     and`units` fields.
- * @param {!Node} node The target node for the tuple.
- */
-function writeMetric(prefix, proto, node) {
-  if (!(proto)) {
-    return;
-  }
-  if (proto.hasValue()) {
-    $(prefix + '_value', node).text(proto.getValue());
-  }
-  if (proto.getUnits) {
-    // proto.ord.Percentage doesn't have units.
-    setSelector($(prefix + '_units', node), proto.getUnits());
-  }
-  if (proto.hasPrecision()) {
-    $(prefix + '_precision', node).text(proto.getPrecision());
-  }
-}
-
-/**
- * Prompts the user to upload a file and sets the target node text with its
- * contents.
- * @param {!Node} identifierNode The node to update with the file contents.
- * @param {string} valueClass The class containing `identifierNode`.
- */
-function setTextFromFile(identifierNode, valueClass) {
-  const input = document.createElement('input');
-  input.type = 'file';
-  input.onchange = (event => {
-    const file = event.target.files[0];
-    const reader = new FileReader();
-    reader.readAsText(file);
-    reader.onload = readerEvent => {
-      const contents = readerEvent.target.result;
-      $('.' + valueClass, identifierNode).text(contents);
-    };
-  });
-  input.click();
-}
-
-/**
- * Adds and populates a <select/> node according to its data-proto type
- * declaration.
- * @param {!Node} node A node containing a `data-proto` attribute.
- */
-function initSelector(node) {
-  const protoName = node.attr('data-proto');
-  const protoEnum = nameToProto(protoName);
-  if (!protoEnum) {
-    console.log('missing require: "' + protoName + '"');
-  }
-  const types = Object.entries(protoEnum);
-  const select = $('<select>');
-  for (let i = 0; i < types.length; i++) {
-    const option = $('<option>').text(types[i][0]);
-    option.attr('value', types[i][1]);
-    if (types[i][0] == 'UNSPECIFIED') {
-      option.attr('selected', 'selected');
-    }
-    select.append(option);
-  }
-  node.append(select);
-}
-
-/**
- * Selects an <option/> under a <select/>.
- * @param {!Node} node A <select/> element.
- * @param {number} value
- */
-function setSelector(node, value) {
-  $('option', node).first().removeAttr('selected');
-  $('option[value=' + value + ']', node).first().attr('selected', 'selected');
-}
-
-/**
- * Finds the selected <option/> and maps its text onto a proto Enum.
- * @param {!Node} node A <select/> element.
- * @return {number}
- */
-function getSelector(node) {
-  return parseInt($('select', node).first().val());
-}
-
-/**
- * Finds the selected <option/> and returns its text.
- * @param {!Node} node A node containing one or more <select/> elements.
- * @return {string}
- */
-function getSelectorText(node) {
-  const selectorElement = node.getElementsByTagName('select')[0];
-  return selectorElement.options[selectorElement.selectedIndex].text;
-}
-
-/**
- * Sets up a three-way popup (true/false/unspecified).
- * @param {!Node} node Target node for the new <select/> element.
- */
-function initOptionalBool(node) {
-  const select = $('<select>');
-  const options = ['UNSPECIFIED', 'TRUE', 'FALSE'];
-  for (let i = 0; i < options.length; i++) {
-    const option = $('<option>').text(options[i]);
-    option.attr('value', options[i]);
-    if (options[i] == 'UNSPECIFIED') {
-      option.attr('selected', 'selected');
-    }
-    select.append(option);
-  }
-  node.append(select);
-}
-
-/**
- * Sets the value of a three-way popup (true/false/unspecified).
- * @param {!Node} node A node containing a three-way selector.
- * @param {boolean|null} value The value to select.
- */
-function setOptionalBool(node, value) {
-  $('option', node).removeAttr('selected');
-  if (value == true) {
-    $('option[value=TRUE]', node).attr('selected', 'selected');
-  }
-  if (value == false) {
-    $('option[value=FALSE]', node).attr('selected', 'selected');
-  }
-  if (value == null) {
-    $('option[value=UNSPECIFIED]', node).attr('selected', 'selected');
-  }
-}
-
-/**
- * Fetches the value of a three-way popup (true/false/unspecified).
- * @param {!Node} node A node containing a three-way selector.
- * @return {boolean|null}
- */
-function getOptionalBool(node) {
-  const value = $('select', node).val();
-  if (value == 'TRUE') {
-    return true;
-  }
-  if (value == 'FALSE') {
-    return false;
-  }
-  return null;
-}
-
-/**
- * Sets up and initializes a collapse button by adding attributes into a div in
- * reaction.html.
- * @param {!Node} node Target node for the new button.
- */
-function initCollapse(node) {
-  node.addClass('fa');
-  node.addClass('fa-chevron-down');
-  node.attr('onclick', 'ord.reaction.collapseToggle(this)');
-  if (node.hasClass('starts_collapsed')) {
-    node.trigger('click');
-  }
-}
-
-/**
- * Sets up a validator div (button, status indicator, error list, etc.) by
- * inserting contents into a div in reaction.html.
- * @param {!Node} oldNode Target node for the new validation elements.
- */
-function initValidateNode(oldNode) {
-  let newNode = $('#validate_template').clone();
-  // Add attributes necessary for validation functions:
-  // Convert the placeholder onclick method into the button's onclick method.
-  $('.validate_button', newNode).attr('onclick', oldNode.attr('onclick'));
-  oldNode.removeAttr('onclick');
-  // Add an id to the button.
-  if (oldNode.attr('id')) {
-    $('.validate_button', newNode).attr('id', oldNode.attr('id') + '_button');
-  }
-  oldNode.append(newNode.children());
 }
 
 /**
@@ -975,90 +427,63 @@ function initValidateNode(oldNode) {
 function initValidateHandlers() {
   // For setup
   const setupNode = $('#section_setup');
-  addChangeHandler(setupNode, () => {
+  ord.utils.addChangeHandler(setupNode, () => {
     ord.setups.validateSetup(setupNode);
   });
 
   // For conditions
   const conditionNode = $('#section_conditions');
-  addChangeHandler(conditionNode, () => {
+  ord.utils.addChangeHandler(conditionNode, () => {
     ord.conditions.validateConditions(conditionNode);
   });
 
   // For temperature
   const temperatureNode = $('#section_conditions_temperature');
-  addChangeHandler(temperatureNode, () => {
+  ord.utils.addChangeHandler(temperatureNode, () => {
     ord.temperature.validateTemperature(temperatureNode);
   });
 
   // For pressure
   const pressureNode = $('#section_conditions_pressure');
-  addChangeHandler(pressureNode, () => {
+  ord.utils.addChangeHandler(pressureNode, () => {
     ord.pressure.validatePressure(pressureNode);
   });
 
   // For stirring
   const stirringNode = $('#section_conditions_stirring');
-  addChangeHandler(stirringNode, () => {
+  ord.utils.addChangeHandler(stirringNode, () => {
     ord.stirring.validateStirring(stirringNode);
   });
 
   // For illumination
   const illuminationNode = $('#section_conditions_illumination');
-  addChangeHandler(illuminationNode, () => {
+  ord.utils.addChangeHandler(illuminationNode, () => {
     ord.illumination.validateIllumination(illuminationNode);
   });
 
   // For electro
   const electroNode = $('#section_conditions_electro');
-  addChangeHandler(electroNode, () => {
+  ord.utils.addChangeHandler(electroNode, () => {
     ord.electro.validateElectro(electroNode);
   });
 
   // For flow
   const flowNode = $('#section_conditions_flow');
-  addChangeHandler(flowNode, () => {
+  ord.utils.addChangeHandler(flowNode, () => {
     ord.flows.validateFlow(flowNode);
   });
 
   // For notes
   const notesNode = $('#section_notes');
-  addChangeHandler(notesNode, () => {
+  ord.utils.addChangeHandler(notesNode, () => {
     ord.notes.validateNotes(notesNode);
   });
 
   // For provenance
   const provenanceNode = $('#section_provenance');
-  addChangeHandler(provenanceNode, () => {
+  ord.utils.addChangeHandler(provenanceNode, () => {
     ord.provenance.validateProvenance(provenanceNode);
   });
-}
-
-/**
- * Converts a Message_Field name from a data-proto attribute into a proto class.
- * @param {string} protoName Underscore-delimited protocol buffer field name,
- *     such as Reaction_provenance.
- * @return {?typeof jspb.Message}
- */
-function nameToProto(protoName) {
-  let clazz = proto.ord;
-  protoName.split('_').forEach(function(name) {
-    clazz = clazz[name];
-    if (!clazz) {
-      return null;
-    }
-  });
-  return clazz;
-}
-
-/**
- * Converts an Enum name string to its protobuf member value.
- * @param {string} name A text representation of an enum member.
- * @param {!enum} protoEnum The protocol buffer enum to search.
- * @return {number}
- */
-function stringToEnum(name, protoEnum) {
-  return protoEnum[name];
 }
 
 /**
@@ -1141,4 +566,25 @@ function updateObserver() {
     const section = selector.attr('input_name');
     session.navSelectors[section] = selector;
   });
+}
+
+/**
+ * Updates the input entries in the sidebar.
+ */
+function updateSidebar() {
+  $('#navInputs').empty();
+  $('.input:visible').not('.workup_input').each(function(index) {
+    const node = $(this);
+    let name = node.find('.input_name').first().text();
+    if (name === '') {
+      name = '(Input #' + (index + 1) + ')';
+    }
+    node.attr('input_name', 'INPUT-' + name);
+    const navNode = $('<div>&#8226; ' + name + '</div>');
+    navNode.addClass('inputNavSection');
+    navNode.attr('input_name', 'INPUT-' + name);
+    $('#navInputs').append(navNode);
+    navNode.click(ord.utils.scrollToInput);
+  });
+  updateObserver();
 }

--- a/js/reaction.js
+++ b/js/reaction.js
@@ -18,14 +18,13 @@ goog.module('ord.reaction');
 goog.module.declareLegacyNamespace();
 exports = {
   commit,
-  dirty,
   downloadReaction,
   freeze,
   initFromDataset,
   initFromReactionId,
-  listen,
   setupObserver,
   toggleAutosave,
+  undoSlowly,
   unloadReaction,
   updateSidebar,
   validateReaction,
@@ -48,7 +47,6 @@ goog.require('ord.temperature');
 goog.require('ord.uploads');
 goog.require('ord.utils');
 goog.require('ord.workups');
-goog.require('proto.ord.Dataset');
 goog.require('proto.ord.Reaction');
 
 // Remember the dataset and reaction we are editing.
@@ -69,13 +67,12 @@ exports.session = session;
  */
 function init(reaction) {
   // Initialize all the template popup menus.
-  $('.selector').each((index, node) => ord.utils.initSelector($(node)));
-  $('.optional_bool')
-      .each((index, node) => ord.utils.initOptionalBool($(node)));
+  $('.selector').each((index, node) => initSelector($(node)));
+  $('.optional_bool').each((index, node) => initOptionalBool($(node)));
   // Enable all the editable text fields.
   $('.edittext').attr('contentEditable', 'true');
   // Initialize all the validators.
-  $('.validate').each((index, node) => ord.utils.initValidateNode($(node)));
+  $('.validate').each((index, node) => initValidateNode($(node)));
   // Initialize validation handlers that don't go in "add" methods.
   initValidateHandlers();
   // Initailize tooltips.
@@ -84,14 +81,14 @@ function init(reaction) {
   // (see github.com/twbs/bootstrap/issues/22610)
   Popper.Defaults.modifiers.computeStyle.gpuAcceleration = false;
   // Show "save" on modifications.
-  listen('body');
+  ord.utils.listen('body');
   // Load Ketcher content into an element with attribute role="application".
   document.getElementById('ketcher-iframe').contentWindow.ketcher.initKetcher();
   // Initialize the UI with the Reaction.
   loadReaction(reaction);
-  clean();
+  ord.utils.clean();
   // Initialize the collaped/uncollapsed state of the fieldset groups.
-  $('.collapse').each((index, node) => ord.utils.initCollapse($(node)));
+  $('.collapse').each((index, node) => initCollapse($(node)));
   // Trigger reaction-level validation.
   validateReaction();
   // Initialize autosave being on.
@@ -109,7 +106,7 @@ async function initFromDataset(fileName, index) {
   session.fileName = fileName;
   session.index = index;
   // Fetch the Dataset containing the Reaction proto.
-  session.dataset = await getDataset(fileName);
+  session.dataset = await ord.utils.getDataset(fileName);
   const reaction = session.dataset.getReactionsList()[index];
   init(reaction);
 }
@@ -119,7 +116,7 @@ async function initFromDataset(fileName, index) {
  * @param {string} reactionId
  */
 async function initFromReactionId(reactionId) {
-  const reaction = await getReactionById(reactionId);
+  const reaction = await ord.utils.getReactionById(reactionId);
   // NOTE(kearnes): Without this next line, `reaction` will be
   // partial/incomplete, and I have no idea why.
   console.log(reaction.toObject());
@@ -128,42 +125,10 @@ async function initFromReactionId(reactionId) {
 }
 
 /**
- * Fetches a reaction as a serialized Reaction proto.
- * @param {string} reactionId The ID of the Reaction to fetch.
- * @return {!Promise<!Uint8Array>}
- */
-function getReactionById(reactionId) {
-  return new Promise(resolve => {
-    const xhr = new XMLHttpRequest();
-    xhr.open('GET', '/reaction/id/' + reactionId + '/proto');
-    xhr.responseType = 'arraybuffer';
-    xhr.onload = function() {
-      const bytes = new Uint8Array(xhr.response);
-      const reaction = proto.ord.Reaction.deserializeBinary(bytes);
-      resolve(reaction);
-    };
-    xhr.send();
-  });
-}
-
-/**
  * Sets the `ready` value to true.
  */
 function ready() {
   $('body').attr('ready', true);
-}
-
-/**
- * Adds a change handler to the given node that shows the 'save' button when
- * the node text is edited.
- * @param {!Node} node
- */
-function listen(node) {
-  ord.utils.addChangeHandler($(node), dirty);
-  $('.edittext', node).on('focus', event => ord.utils.selectText(event.target));
-  $('.floattext', node).on('blur', event => ord.utils.checkFloat(event.target));
-  $('.integertext', node)
-      .on('blur', event => ord.utils.checkInteger(event.target));
 }
 
 /**
@@ -185,37 +150,20 @@ function clickSave() {
  */
 function toggleAutosave() {
   // We keep track of timers by holding references, only if they're active.
-  const autosave = $('#toggle_autosave');
   if (!session.timers.short) {
     // Enable a simple timer that saves periodically.
     session.timers.short =
         setInterval(clickSave, 1000 * 15);  // Save after 15 seconds
-    autosave.text('autosave: on');
-    autosave.css('backgroundColor', 'lightgreen');
+    $('#toggle_autosave').text('autosave: on');
+    $('#toggle_autosave').css('backgroundColor', 'lightgreen');
   } else {
     // Stop the interval timer itself, then remove reference in order to
     // properly later detect that it's stopped.
     clearInterval(session.timers.short);
     session.timers.short = null;
-    autosave.text('autosave: off');
-    autosave.css('backgroundColor', 'pink');
+    $('#toggle_autosave').text('autosave: off');
+    $('#toggle_autosave').css('backgroundColor', 'pink');
   }
-}
-
-/**
- * Shows the 'save' button.
- */
-function dirty() {
-  $('#save').css('visibility', 'visible');
-}
-
-/**
- * Hides the 'save' button.
- */
-function clean() {
-  const save = $('#save');
-  save.css('visibility', 'hidden');
-  save.text('save');
 }
 
 /**
@@ -259,7 +207,7 @@ function commit() {
   const reaction = unloadReaction();
   const reactions = session.dataset.getReactionsList();
   reactions[session.index] = reaction;
-  ord.utils.putDataset(session.fileName, session.dataset);
+  putDataset(session.fileName, session.dataset);
   ord.uploads.putAll(session.fileName);
 }
 
@@ -284,25 +232,6 @@ function downloadReaction() {
 }
 
 /**
- * Downloads a dataset as a serialized Dataset proto.
- * @param {string} fileName The name of the dataset to fetch.
- * @return {!Promise<!Uint8Array>}
- */
-function getDataset(fileName) {
-  return new Promise(resolve => {
-    const xhr = new XMLHttpRequest();
-    xhr.open('GET', '/dataset/proto/read/' + fileName);
-    xhr.responseType = 'arraybuffer';
-    xhr.onload = function(event) {
-      const bytes = new Uint8Array(xhr.response);
-      const dataset = proto.ord.Dataset.deserializeBinary(bytes);
-      resolve(dataset);
-    };
-    xhr.send();
-  });
-}
-
-/**
  * Uploads a serialized Dataset proto.
  * @param {string} fileName The name of the new dataset.
  * @param {!proto.ord.Dataset} dataset
@@ -312,7 +241,7 @@ function putDataset(fileName, dataset) {
   const xhr = new XMLHttpRequest();
   xhr.open('POST', '/dataset/proto/write/' + fileName);
   const binary = dataset.serializeBinary();
-  xhr.onload = clean;
+  xhr.onload = ord.utils.clean;
   xhr.send(binary);
 }
 
@@ -416,6 +345,147 @@ function unloadReaction() {
   // Setter does nothing when passed an empty string.
   reaction.setReactionId($('#reaction_id').text());
   return reaction;
+}
+
+/**
+ * Reverses the hide() in the most recent invocation of removeSlowly().
+ * Removes the node's "undo" button. Does not trigger validation.
+ */
+function undoSlowly() {
+  $('.undoable').removeClass('undoable').show('slow');
+  $('.undo').not('#undo_template').hide('slow', function() {
+    $(this).remove();
+    updateSidebar();
+  });
+  ord.utils.dirty();
+}
+
+/**
+ * Marks the given node for possible future undo. Adds an "undo" button to do
+ * it. Deletes any preexisting undoable nodes and undo buttons.
+ * @param {!Node} node The DOM fragment to hide and re-show.
+ */
+function makeUndoable(node) {
+  $('.undoable').remove();
+  node.addClass('undoable');
+  $('.undo').not('#undo_template').remove();
+  const button = $('#undo_template').clone();
+  button.removeAttr('id');
+  node.after(button);
+  button.show('slow');
+}
+
+/**
+ * Toggles the visibility of all siblings of an element, or if a pattern is
+ * provided, toggles the visibility of all siblings of the nearest ancestor
+ * element matching the pattern.
+ * @param {!Node} node The element to toggle or use as the search root.
+ * @param {string} pattern The pattern to match for finding siblings to toggle.
+ */
+function toggleSlowly(node, pattern) {
+  node = $(node);
+  if (pattern) {
+    node = node.closest(pattern);
+  }
+  // 'collapsed' tag is used to hold previously collapsed siblings,
+  // and would be stored as node's next sibling;
+  // the following line checks whether a collapse has occured.
+  if (node.next('collapsed').length !== 0) {
+    // Need to uncollapse.
+    const collapsedNode = node.next('collapsed');
+    collapsedNode.toggle('slow', () => {
+      collapsedNode.children().unwrap();
+    });
+  } else {
+    // Need to collapse.
+    node.siblings().wrapAll('<collapsed>');
+    node.next('collapsed').toggle('slow');
+  }
+}
+
+/**
+ * Toggles the collapse of a section in the form.
+ * @param {string} button The element to toggle.
+ */
+function collapseToggle(button) {
+  $(button).toggleClass('fa-chevron-down fa-chevron-right');
+  toggleSlowly(button, 'legend');
+}
+
+/**
+ * Adds and populates a <select/> node according to its data-proto type
+ * declaration.
+ * @param {!Node} node A node containing a `data-proto` attribute.
+ */
+function initSelector(node) {
+  const protoName = node.attr('data-proto');
+  const protoEnum = ord.utils.nameToProto(protoName);
+  if (!protoEnum) {
+    console.log('missing require: "' + protoName + '"');
+  }
+  const types = Object.entries(protoEnum);
+  const select = $('<select>');
+  for (let i = 0; i < types.length; i++) {
+    const option = $('<option>').text(types[i][0]);
+    option.attr('value', types[i][1]);
+    if (types[i][0] === 'UNSPECIFIED') {
+      option.attr('selected', 'selected');
+    }
+    select.append(option);
+  }
+  node.append(select);
+}
+
+/**
+ * Sets up a three-way popup (true/false/unspecified).
+ * @param {!Node} node Target node for the new <select/> element.
+ */
+function initOptionalBool(node) {
+  const select = $('<select>');
+  const options = ['UNSPECIFIED', 'TRUE', 'FALSE'];
+  for (let i = 0; i < options.length; i++) {
+    const option = $('<option>').text(options[i]);
+    option.attr('value', options[i]);
+    if (options[i] === 'UNSPECIFIED') {
+      option.attr('selected', 'selected');
+    }
+    select.append(option);
+  }
+  node.append(select);
+}
+
+/**
+ * Sets up and initializes a collapse button by adding attributes into a div in
+ * reaction.html.
+ * @param {!Node} node Target node for the new button.
+ */
+function initCollapse(node) {
+  node.addClass('fa');
+  node.addClass('fa-chevron-down');
+  node.click(function() {
+    collapseToggle(this);
+  });
+  if (node.hasClass('starts_collapsed')) {
+    node.trigger('click');
+  }
+}
+
+/**
+ * Sets up a validator div (button, status indicator, error list, etc.) by
+ * inserting contents into a div in reaction.html.
+ * @param {!Node} oldNode Target node for the new validation elements.
+ */
+function initValidateNode(oldNode) {
+  let newNode = $('#validate_template').clone();
+  // Add attributes necessary for validation functions:
+  // Convert the placeholder onclick method into the button's onclick method.
+  $('.validate_button', newNode).attr('onclick', oldNode.attr('onclick'));
+  oldNode.removeAttr('onclick');
+  // Add an id to the button.
+  if (oldNode.attr('id')) {
+    $('.validate_button', newNode).attr('id', oldNode.attr('id') + '_button');
+  }
+  oldNode.append(newNode.children());
 }
 
 /**
@@ -569,6 +639,16 @@ function updateObserver() {
 }
 
 /**
+ * Scrolls the viewport to the selected input.
+ * @param {!Event} event
+ */
+function scrollToInput(event) {
+  const section = $(event.target).attr('input_name');
+  const target = $('.input[input_name=\'' + section + '\']');
+  target[0].scrollIntoView({behavior: 'smooth'});
+}
+
+/**
  * Updates the input entries in the sidebar.
  */
 function updateSidebar() {
@@ -584,7 +664,7 @@ function updateSidebar() {
     navNode.addClass('inputNavSection');
     navNode.attr('input_name', 'INPUT-' + name);
     $('#navInputs').append(navNode);
-    navNode.click(ord.utils.scrollToInput);
+    navNode.click(scrollToInput);
   });
   updateObserver();
 }

--- a/js/setups.js
+++ b/js/setups.js
@@ -25,6 +25,7 @@ exports = {
 };
 
 goog.require('ord.codes');
+goog.require('ord.utils');
 goog.require('proto.ord.ReactionSetup');
 goog.require('proto.ord.Vessel');
 goog.require('proto.ord.Volume');
@@ -39,13 +40,13 @@ function load(setup) {
     loadVessel(vessel);
   }
   const isAutomated = setup.hasIsAutomated() ? setup.getIsAutomated() : null;
-  ord.reaction.setOptionalBool($('#setup_automated'), isAutomated);
+  ord.utils.setOptionalBool($('#setup_automated'), isAutomated);
   if (isAutomated) {
     $('#automation_platform').show();
   }
 
   $('#setup_automated').change(function() {
-    if (ord.reaction.getSelectorText(this) == 'TRUE') {
+    if (ord.utils.getSelectorText(this) == 'TRUE') {
       $('#automation_platform').show();
     } else {
       $('#automation_platform').hide();
@@ -60,8 +61,7 @@ function load(setup) {
 
   const environment = setup.getEnvironment();
   if (environment != null) {
-    ord.reaction.setSelector(
-        $('#setup_environment_type'), environment.getType());
+    ord.utils.setSelector($('#setup_environment_type'), environment.getType());
     $('#setup_environment_details').text(environment.getDetails());
   }
 }
@@ -73,31 +73,31 @@ function load(setup) {
 function loadVessel(vessel) {
   const type = vessel.getType();
   if (type) {
-    ord.reaction.setSelector($('#setup_vessel_type'), type.getType());
+    ord.utils.setSelector($('#setup_vessel_type'), type.getType());
     $('#setup_vessel_details').text(type.getDetails());
   }
   const material = vessel.getMaterial();
   if (material) {
-    ord.reaction.setSelector($('#setup_vessel_material'), material.getType());
+    ord.utils.setSelector($('#setup_vessel_material'), material.getType());
     $('#setup_vessel_material_details').text(material.getDetails());
   }
   const preparations = vessel.getPreparationsList();
   preparations.forEach(preparation => {
     const node = addVesselPreparation();
-    ord.reaction.setSelector(
+    ord.utils.setSelector(
         $('.setup_vessel_preparation_type', node), preparation.getType());
     $('.setup_vessel_preparation_details', node).text(preparation.getDetails());
   });
   const attachments = vessel.getAttachmentsList();
   attachments.forEach(attachment => {
     const node = addVesselAttachment();
-    ord.reaction.setSelector(
+    ord.utils.setSelector(
         $('.setup_vessel_attachment_type', node), attachment.getType());
     $('.setup_vessel_attachment_details', node).text(attachment.getDetails());
   });
   if (vessel.hasVolume()) {
     const volume = vessel.getVolume();
-    ord.reaction.writeMetric('#setup_vessel_volume', volume);
+    ord.utils.writeMetric('#setup_vessel_volume', volume);
   }
 }
 
@@ -109,11 +109,11 @@ function unload() {
   const setup = new proto.ord.ReactionSetup();
 
   const vessel = unloadVessel();
-  if (!ord.reaction.isEmptyMessage(vessel)) {
+  if (!ord.utils.isEmptyMessage(vessel)) {
     setup.setVessel(vessel);
   }
 
-  const isAutomated = ord.reaction.getOptionalBool($('#setup_automated'));
+  const isAutomated = ord.utils.getOptionalBool($('#setup_automated'));
   setup.setIsAutomated(isAutomated);
 
   const platform = $('#setup_platform').text();
@@ -123,9 +123,9 @@ function unload() {
   ord.codes.unload(codes);
 
   const environment = new proto.ord.ReactionSetup.ReactionEnvironment();
-  environment.setType(ord.reaction.getSelector($('#setup_environment_type')));
+  environment.setType(ord.utils.getSelector($('#setup_environment_type')));
   environment.setDetails($('#setup_environment_details').text());
-  if (!ord.reaction.isEmptyMessage(environment)) {
+  if (!ord.utils.isEmptyMessage(environment)) {
     setup.setEnvironment(environment);
   }
 
@@ -140,31 +140,31 @@ function unloadVessel() {
   const vessel = new proto.ord.Vessel();
 
   const type = new proto.ord.VesselType();
-  type.setType(ord.reaction.getSelector($('#setup_vessel_type')));
+  type.setType(ord.utils.getSelector($('#setup_vessel_type')));
   type.setDetails($('#setup_vessel_details').text());
-  if (!ord.reaction.isEmptyMessage(type)) {
+  if (!ord.utils.isEmptyMessage(type)) {
     vessel.setType(type);
   }
 
   const material = new proto.ord.VesselMaterial();
-  material.setType(ord.reaction.getSelector('#setup_vessel_material'));
+  material.setType(ord.utils.getSelector('#setup_vessel_material'));
   material.setDetails($('#setup_vessel_material_details').text());
-  if (!ord.reaction.isEmptyMessage(material)) {
+  if (!ord.utils.isEmptyMessage(material)) {
     vessel.setMaterial(material);
   }
 
   const preparations = [];
   $('.setup_vessel_preparation').each(function(index, node) {
     node = $(node);
-    if (ord.reaction.isTemplateOrUndoBuffer(node)) {
+    if (ord.utils.isTemplateOrUndoBuffer(node)) {
       // The template.
       return;
     }
     const preparation = new proto.ord.VesselPreparation();
     preparation.setType(
-        ord.reaction.getSelector($('.setup_vessel_preparation_type', node)));
+        ord.utils.getSelector($('.setup_vessel_preparation_type', node)));
     preparation.setDetails($('.setup_vessel_preparation_details', node).text());
-    if (!ord.reaction.isEmptyMessage(preparation)) {
+    if (!ord.utils.isEmptyMessage(preparation)) {
       preparations.push(preparation);
     }
   });
@@ -173,22 +173,22 @@ function unloadVessel() {
   const attachments = [];
   $('.setup_vessel_attachment').each(function(index, node) {
     node = $(node);
-    if (ord.reaction.isTemplateOrUndoBuffer(node)) {
+    if (ord.utils.isTemplateOrUndoBuffer(node)) {
       return;
     }
     const attachment = new proto.ord.VesselAttachment();
     attachment.setType(
-        ord.reaction.getSelector($('.setup_vessel_attachment_type', node)));
+        ord.utils.getSelector($('.setup_vessel_attachment_type', node)));
     attachment.setDetails($('.setup_vessel_attachment_details', node).text());
-    if (!ord.reaction.isEmptyMessage(attachment)) {
+    if (!ord.utils.isEmptyMessage(attachment)) {
       attachments.push(attachment);
     }
   });
   vessel.setAttachmentsList(attachments);
 
   const volume =
-      ord.reaction.readMetric('#setup_vessel_volume', new proto.ord.Volume());
-  if (!ord.reaction.isEmptyMessage(volume)) {
+      ord.utils.readMetric('#setup_vessel_volume', new proto.ord.Volume());
+  if (!ord.utils.isEmptyMessage(volume)) {
     vessel.setVolume(volume);
   }
 
@@ -200,7 +200,7 @@ function unloadVessel() {
  * @return {!Node} The node of the newly added div.
  */
 function addVesselPreparation() {
-  return ord.reaction.addSlowly(
+  return ord.utils.addSlowly(
       '#setup_vessel_preparation_template', '#setup_vessel_preparations');
 }
 
@@ -209,7 +209,7 @@ function addVesselPreparation() {
  * @return {!Node} The node of the newly added div.
  */
 function addVesselAttachment() {
-  return ord.reaction.addSlowly(
+  return ord.utils.addSlowly(
       '#setup_vessel_attachment_template', '#setup_vessel_attachments');
 }
 
@@ -218,7 +218,7 @@ function addVesselAttachment() {
  * @param {!Node} node The node containing the reaction setup div.
  * @param {?Node} validateNode The target div for validation results.
  */
-function validateSetup(node, validateNode) {
+function validateSetup(node, validateNode = null) {
   const setup = unload();
-  ord.reaction.validate(setup, 'ReactionSetup', node, validateNode);
+  ord.utils.validate(setup, 'ReactionSetup', node, validateNode);
 }

--- a/js/setups.js
+++ b/js/setups.js
@@ -216,7 +216,7 @@ function addVesselAttachment() {
 /**
  * Validates the reaction setup defined in the form.
  * @param {!Node} node The node containing the reaction setup div.
- * @param {?Node} validateNode The target div for validation results.
+ * @param {?Node=} validateNode The target div for validation results.
  */
 function validateSetup(node, validateNode = null) {
   const setup = unload();

--- a/js/stirring.js
+++ b/js/stirring.js
@@ -22,6 +22,7 @@ exports = {
   validateStirring
 };
 
+goog.require('ord.utils');
 goog.require('proto.ord.StirringConditions');
 
 /**
@@ -31,12 +32,12 @@ goog.require('proto.ord.StirringConditions');
 function load(stirring) {
   const method = stirring.getMethod();
   if (method) {
-    ord.reaction.setSelector($('#stirring_method_type'), method.getType());
+    ord.utils.setSelector($('#stirring_method_type'), method.getType());
     $('#stirring_method_details').text(method.getDetails());
   }
   const rate = stirring.getRate();
   if (rate) {
-    ord.reaction.setSelector($('#stirring_rate_type'), rate.getType());
+    ord.utils.setSelector($('#stirring_rate_type'), rate.getType());
     $('#stirring_rate_details').text(rate.getDetails());
     const rpm = rate.getRpm();
     if (rpm != 0) {
@@ -53,20 +54,20 @@ function unload() {
   const stirring = new proto.ord.StirringConditions();
 
   const method = new proto.ord.StirringConditions.StirringMethod();
-  method.setType(ord.reaction.getSelector($('#stirring_method_type')));
+  method.setType(ord.utils.getSelector($('#stirring_method_type')));
   method.setDetails($('#stirring_method_details').text());
-  if (!ord.reaction.isEmptyMessage(method)) {
+  if (!ord.utils.isEmptyMessage(method)) {
     stirring.setMethod(method);
   }
 
   const rate = new proto.ord.StirringConditions.StirringRate();
-  rate.setType(ord.reaction.getSelector($('#stirring_rate_type')));
+  rate.setType(ord.utils.getSelector($('#stirring_rate_type')));
   rate.setDetails($('#stirring_rate_details').text());
   const rpm = parseFloat($('#stirring_rpm').text());
   if (!isNaN(rpm)) {
     rate.setRpm(rpm);
   }
-  if (!ord.reaction.isEmptyMessage(rate)) {
+  if (!ord.utils.isEmptyMessage(rate)) {
     stirring.setRate(rate);
   }
   return stirring;
@@ -77,7 +78,7 @@ function unload() {
  * @param {!Node} node The div containing the stirring conditions.
  * @param {?Node} validateNode The target div for validation results.
  */
-function validateStirring(node, validateNode) {
+function validateStirring(node, validateNode = null) {
   const stirring = unload();
-  ord.reaction.validate(stirring, 'StirringConditions', node, validateNode);
+  ord.utils.validate(stirring, 'StirringConditions', node, validateNode);
 }

--- a/js/stirring.js
+++ b/js/stirring.js
@@ -76,7 +76,7 @@ function unload() {
 /**
  * Validates the stirring conditions defined in the form.
  * @param {!Node} node The div containing the stirring conditions.
- * @param {?Node} validateNode The target div for validation results.
+ * @param {?Node=} validateNode The target div for validation results.
  */
 function validateStirring(node, validateNode = null) {
   const stirring = unload();

--- a/js/temperature.js
+++ b/js/temperature.js
@@ -138,7 +138,7 @@ function addMeasurement() {
 /**
  * Validates temperature conditions defined in the form.
  * @param {!Node} node The node containing the temperature conditions div.
- * @param {?Node} validateNode The target div for validation results.
+ * @param {?Node=} validateNode The target div for validation results.
  */
 function validateTemperature(node, validateNode = null) {
   const temperature = unload();

--- a/js/temperature.js
+++ b/js/temperature.js
@@ -23,6 +23,7 @@ exports = {
   validateTemperature
 };
 
+goog.require('ord.utils');
 goog.require('proto.ord.Temperature');
 goog.require('proto.ord.TemperatureConditions');
 goog.require('proto.ord.TemperatureConditions.Measurement');
@@ -36,7 +37,7 @@ goog.require('proto.ord.Time');
 function load(temperature) {
   const control = temperature.getControl();
   if (control) {
-    ord.reaction.setSelector($('#temperature_control'), control.getType());
+    ord.utils.setSelector($('#temperature_control'), control.getType());
     $('#temperature_control_details').text(control.getDetails());
   }
   const measurements = temperature.getMeasurementsList();
@@ -45,7 +46,7 @@ function load(temperature) {
     loadMeasurement(measurement, node);
   });
   const setpoint = temperature.getSetpoint();
-  ord.reaction.writeMetric('#temperature_setpoint', setpoint);
+  ord.utils.writeMetric('#temperature_setpoint', setpoint);
 }
 
 /**
@@ -55,15 +56,15 @@ function load(temperature) {
  */
 function loadMeasurement(measurement, node) {
   const type = measurement.getType();
-  ord.reaction.setSelector($('.temperature_measurement_type', node), type);
+  ord.utils.setSelector($('.temperature_measurement_type', node), type);
   $('.temperature_measurement_details', node).text(measurement.getDetails());
 
   const temperature = measurement.getTemperature();
-  ord.reaction.writeMetric(
+  ord.utils.writeMetric(
       '.temperature_measurement_temperature', temperature, node);
 
   const time = measurement.getTime();
-  ord.reaction.writeMetric('.temperature_measurement_time', time, node);
+  ord.utils.writeMetric('.temperature_measurement_time', time, node);
 }
 
 /**
@@ -74,24 +75,24 @@ function unload() {
   const temperature = new proto.ord.TemperatureConditions();
 
   const control = new proto.ord.TemperatureConditions.TemperatureControl();
-  control.setType(ord.reaction.getSelector($('#temperature_control')));
+  control.setType(ord.utils.getSelector($('#temperature_control')));
   control.setDetails($('#temperature_control_details').text());
-  if (!ord.reaction.isEmptyMessage(control)) {
+  if (!ord.utils.isEmptyMessage(control)) {
     temperature.setControl(control);
   }
 
-  const setpoint = ord.reaction.readMetric(
+  const setpoint = ord.utils.readMetric(
       '#temperature_setpoint', new proto.ord.Temperature());
-  if (!ord.reaction.isEmptyMessage(setpoint)) {
+  if (!ord.utils.isEmptyMessage(setpoint)) {
     temperature.setSetpoint(setpoint);
   }
 
   const measurements = [];
   $('.temperature_measurement').each(function(index, node) {
     node = $(node);
-    if (!ord.reaction.isTemplateOrUndoBuffer(node)) {
+    if (!ord.utils.isTemplateOrUndoBuffer(node)) {
       const measurement = unloadMeasurement(node);
-      if (!ord.reaction.isEmptyMessage(measurement)) {
+      if (!ord.utils.isEmptyMessage(measurement)) {
         measurements.push(measurement);
       }
     }
@@ -107,20 +108,19 @@ function unload() {
  */
 function unloadMeasurement(node) {
   const measurement = new proto.ord.TemperatureConditions.Measurement();
-  const type =
-      ord.reaction.getSelector($('.temperature_measurement_type', node));
+  const type = ord.utils.getSelector($('.temperature_measurement_type', node));
   measurement.setType(type);
   const details = $('.temperature_measurement_details', node).text();
   measurement.setDetails(details);
-  const temperature = ord.reaction.readMetric(
+  const temperature = ord.utils.readMetric(
       '.temperature_measurement_temperature', new proto.ord.Temperature(),
       node);
-  if (!ord.reaction.isEmptyMessage(temperature)) {
+  if (!ord.utils.isEmptyMessage(temperature)) {
     measurement.setTemperature(temperature);
   }
-  const time = ord.reaction.readMetric(
+  const time = ord.utils.readMetric(
       '.temperature_measurement_time', new proto.ord.Time(), node);
-  if (!ord.reaction.isEmptyMessage(time)) {
+  if (!ord.utils.isEmptyMessage(time)) {
     measurement.setTime(time);
   }
   return measurement;
@@ -131,7 +131,7 @@ function unloadMeasurement(node) {
  * @return {!Node} The node of the new measurement div.
  */
 function addMeasurement() {
-  return ord.reaction.addSlowly(
+  return ord.utils.addSlowly(
       '#temperature_measurement_template', '#temperature_measurements');
 }
 
@@ -140,8 +140,7 @@ function addMeasurement() {
  * @param {!Node} node The node containing the temperature conditions div.
  * @param {?Node} validateNode The target div for validation results.
  */
-function validateTemperature(node, validateNode) {
+function validateTemperature(node, validateNode = null) {
   const temperature = unload();
-  ord.reaction.validate(
-      temperature, 'TemperatureConditions', node, validateNode);
+  ord.utils.validate(temperature, 'TemperatureConditions', node, validateNode);
 }

--- a/js/test.js
+++ b/js/test.js
@@ -49,7 +49,7 @@ const puppeteer = require('puppeteer');
       const session = ord.reaction.session;
       const reactions = session.dataset.getReactionsList();
       reactions[session.index] = reaction;
-      return ord.reaction.compareDataset(session.fileName, session.dataset)
+      return ord.utils.compareDataset(session.fileName, session.dataset)
           .then(() => {
             console.log('PASS', url);
             return 0;

--- a/js/test.js
+++ b/js/test.js
@@ -46,7 +46,7 @@ const puppeteer = require('puppeteer');
     await page.waitFor('body[ready=true]');
     const testResult = await page.evaluate(function(url) {
       const reaction = ord.reaction.unloadReaction();
-      const session = ord.reaction.session;
+      const session = ord.utils.session;
       const reactions = session.dataset.getReactionsList();
       reactions[session.index] = reaction;
       return ord.utils.compareDataset(session.fileName, session.dataset)

--- a/js/utils.js
+++ b/js/utils.js
@@ -20,6 +20,7 @@ exports = {
   addChangeHandler,
   addSlowly,
   clean,
+  collapseToggle,  // Used by initCollapse.
   compareDataset,
   getDataset,
   getOptionalBool,
@@ -293,9 +294,7 @@ function initOptionalBool(node) {
 function initCollapse(node) {
   node.addClass('fa');
   node.addClass('fa-chevron-down');
-  node.click(function() {
-    collapseToggle(this);
-  });
+  node.attr('onclick', 'ord.utils.collapseToggle(this)');
   if (node.hasClass('starts_collapsed')) {
     node.trigger('click');
   }

--- a/js/utils.js
+++ b/js/utils.js
@@ -1,0 +1,1144 @@
+/**
+ * Copyright 2020 Open Reaction Database Project Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+goog.module('ord.reaction');
+goog.module.declareLegacyNamespace();
+exports = {
+  initFromDataset,
+  initFromReactionId,
+  commit,
+  toggleAutosave,
+  downloadReaction,
+  validateReaction,
+  setTextFromFile,
+  removeSlowly,
+  collapseToggle,
+  addSlowly,
+  addChangeHandler,
+  validate,
+  toggleValidateMessage,
+  compareDataset,
+  unloadReaction,
+  isEmptyMessage,
+  readMetric,
+  writeMetric,
+  setSelector,
+  getSelector,
+  getSelectorText,
+  setOptionalBool,
+  getOptionalBool,
+  freeze,
+  setupObserver,
+  updateObserver,
+  undoSlowly,
+  isTemplateOrUndoBuffer
+};
+
+goog.require('ord.conditions');
+goog.require('ord.enums');
+goog.require('ord.identifiers');
+goog.require('ord.inputs');
+goog.require('ord.notes');
+goog.require('ord.observations');
+goog.require('ord.outcomes');
+goog.require('ord.provenance');
+goog.require('ord.setups');
+goog.require('ord.workups');
+goog.require('proto.ord.Dataset');
+goog.require('proto.ord.Reaction');
+
+// Remember the dataset and reaction we are editing.
+const session = {
+  fileName: null,
+  dataset: null,
+  index: null,             // Ordinal position of the Reaction in its Dataset.
+  observer: null,          // IntersectionObserver used for the sidebar.
+  navSelectors: {},        // Dictionary from navigation to section.
+  timers: {'short': null}  // A timer used by autosave.
+};
+// Export session, because it's used by test.js.
+exports.session = session;
+
+const FLOAT_PATTERN = /^-?(?:\d+|\d+\.\d*|\d*\.\d+)(?:[eE]-?\d+)?$/;
+const INTEGER_PATTERN = /^-?\d+$/;
+
+/**
+ * Initializes the form.
+ * @param {!proto.ord.Reaction} reaction Reaction proto to load.
+ */
+function init(reaction) {
+  // Initialize all the template popup menus.
+  $('.selector').each((index, node) => initSelector($(node)));
+  $('.optional_bool').each((index, node) => initOptionalBool($(node)));
+  // Enable all the editable text fields.
+  $('.edittext').attr('contentEditable', 'true');
+  // Initialize all the validators.
+  $('.validate').each((index, node) => initValidateNode($(node)));
+  // Initialize validation handlers that don't go in "add" methods.
+  initValidateHandlers();
+  // Initailize tooltips.
+  $('[data-toggle=\'tooltip\']').tooltip();
+  // Prevent tooltip pop-ups from blurring.
+  // (see github.com/twbs/bootstrap/issues/22610)
+  Popper.Defaults.modifiers.computeStyle.gpuAcceleration = false;
+  // Show "save" on modifications.
+  listen('body');
+  // Load Ketcher content into an element with attribute role="application".
+  document.getElementById('ketcher-iframe').contentWindow.ketcher.initKetcher();
+  // Initialize the UI with the Reaction.
+  loadReaction(reaction);
+  clean();
+  // Initialize the collaped/uncollapsed state of the fieldset groups.
+  $('.collapse').each((index, node) => initCollapse($(node)));
+  // Trigger reaction-level validation.
+  validateReaction();
+  // Initialize autosave being on.
+  toggleAutosave();
+  // Signal to tests that the DOM is initialized.
+  ready();
+}
+
+/**
+ * Initializes the form from a Dataset name and Reaction index.
+ * @param {string} fileName Path to a Dataset proto.
+ * @param {number} index The index of this Reaction in the Dataset.
+ */
+async function initFromDataset(fileName, index) {
+  session.fileName = fileName;
+  session.index = index;
+  // Fetch the Dataset containing the Reaction proto.
+  session.dataset = await getDataset(fileName);
+  const reaction = session.dataset.getReactionsList()[index];
+  init(reaction);
+}
+
+/**
+ * Initializes the form from a Reaction ID.
+ * @param {string} reactionId
+ */
+async function initFromReactionId(reactionId) {
+  const reaction = await getReactionById(reactionId);
+  // NOTE(kearnes): Without this next line, `reaction` will be
+  // partial/incomplete, and I have no idea why.
+  console.log(reaction.toObject());
+  init(reaction);
+  $('#dataset_context').hide();
+}
+
+/**
+ * Fetches a reaction as a serialized Reaction proto.
+ * @param {string} reactionId The ID of the Reaction to fetch.
+ * @return {!Promise<!Uint8Array>}
+ */
+function getReactionById(reactionId) {
+  return new Promise(resolve => {
+    const xhr = new XMLHttpRequest();
+    xhr.open('GET', '/reaction/id/' + reactionId + '/proto');
+    xhr.responseType = 'arraybuffer';
+    xhr.onload = function() {
+      const bytes = new Uint8Array(xhr.response);
+      const reaction = proto.ord.Reaction.deserializeBinary(bytes);
+      resolve(reaction);
+    };
+    xhr.send();
+  });
+}
+
+/**
+ * Sets the `ready` value to true.
+ */
+function ready() {
+  $('body').attr('ready', true);
+}
+
+/**
+ * Adds a change handler to the given node that shows the 'save' button when
+ * the node text is edited.
+ * @param {!Node} node
+ */
+function listen(node) {
+  addChangeHandler($(node), dirty);
+  $('.edittext', node).on('focus', event => selectText(event.target));
+  $('.floattext', node).on('blur', event => checkFloat(event.target));
+  $('.integertext', node).on('blur', event => checkInteger(event.target));
+}
+
+/**
+ * Clicks the 'save' button if ready for a save.
+ */
+function clickSave() {
+  // Only save if there are unsaved changes still to be saved -- hence save
+  // button visible -- and if ready for a save (not in the process of saving
+  // already).
+  const saveButton = $('#save');
+  if (saveButton.css('visibility') == 'visible' &&
+      saveButton.text() == 'save') {
+    saveButton.click();
+  }
+}
+
+/**
+ * Toggles autosave being active.
+ */
+function toggleAutosave() {
+  // We keep track of timers by holding references, only if they're active.
+  if (!session.timers['short']) {
+    // Enable a simple timer that saves periodically.
+    session.timers['short'] =
+        setInterval(clickSave, 1000 * 15);  // Save after 15 seconds
+    $('#toggle_autosave').text('autosave: on');
+    $('#toggle_autosave').css('backgroundColor', 'lightgreen');
+  } else {
+    // Stop the interval timer itself, then remove reference in order to
+    // properly later detect that it's stopped.
+    clearInterval(session.timers['short']);
+    session.timers['short'] = null;
+    $('#toggle_autosave').text('autosave: off');
+    $('#toggle_autosave').css('backgroundColor', 'pink');
+  }
+}
+
+/**
+ * Shows the 'save' button.
+ */
+function dirty() {
+  $('#save').css('visibility', 'visible');
+}
+
+/**
+ * Hides the 'save' button.
+ */
+function clean() {
+  $('#save').css('visibility', 'hidden');
+  $('#save').text('save');
+}
+
+/**
+ * Selects the contents of the given node.
+ * @param {!Node} node
+ */
+function selectText(node) {
+  const range = document.createRange();
+  range.selectNodeContents(node);
+  const selection = window.getSelection();
+  selection.removeAllRanges();
+  selection.addRange(range);
+}
+
+/**
+ * Determines if the text entered in a float input is valid by detecting any
+ * characters besides 0-9, a single period to signify a decimal, and a
+ * leading hyphen. Also supports scientific notation with either 'e' or 'E'.
+ * @param {!Node} node
+ */
+function checkFloat(node) {
+  const stringValue = $(node).text().trim();
+  if (stringValue === '') {
+    $(node).removeClass('invalid');
+  } else if (FLOAT_PATTERN.test(stringValue)) {
+    $(node).removeClass('invalid');
+  } else {
+    $(node).addClass('invalid');
+  }
+}
+
+/**
+ * Determines if the text entered in an integer input is valid by forbidding
+ * any characters besides 0-9 and a leading hyphen.
+ * @param {!Node} node
+ */
+function checkInteger(node) {
+  const stringValue = $(node).text().trim();
+  if (stringValue === '') {
+    $(node).removeClass('invalid');
+  } else if (INTEGER_PATTERN.test(stringValue)) {
+    $(node).removeClass('invalid');
+  } else {
+    $(node).addClass('invalid');
+  }
+}
+
+/**
+ * Prepares a floating point value for display in the form.
+ * @param {number} value
+ * @return {number}
+ */
+function prepareFloat(value) {
+  // Round to N significant digits; this avoid floating point precision issues
+  // that can be quite jarring to users.
+  //
+  // See:
+  //   * https://stackoverflow.com/a/3644302
+  //   * https://medium.com/swlh/ed74c471c1b8
+  //   * https://stackoverflow.com/a/19623253
+  const precision = 7;
+  return parseFloat(value.toPrecision(precision));
+}
+
+/**
+ * Adds a jQuery handler to a node such that the handler is run once whenever
+ * data entry within that node is changed, *except through remove* -- this must
+ * be handled manually. (This prevents inconsistent timing in the ordering of
+ * the element being removed and the handler being called.)
+ * @param {!Node} node
+ * @param {!Function} handler
+ */
+function addChangeHandler(node, handler) {
+  // For textboxes
+  node.on('blur', '.edittext', handler);
+  // For selectors, optional bool selectors,
+  // and checkboxes/radio buttons/file upload, respectively
+  node.on('change', '.selector, .optional_bool, input', handler);
+  // For add buttons
+  node.on('click', '.add', handler);
+}
+
+/**
+ * Generic validator for many message types, not just reaction.
+ * NOTE: This function does not commit or save anything!
+ * @param {!jspb.Message} message The proto to validate.
+ * @param {string} messageTypeString The message type.
+ * @param {!Node} node Parent node for the unloaded message.
+ * @param {?Node} validateNode Target div for validation output.
+ */
+function validate(message, messageTypeString, node, validateNode) {
+  // eg message is a type of reaction, messageTypeString = 'Reaction'
+  const xhr = new XMLHttpRequest();
+  xhr.open('POST', '/dataset/proto/validate/' + messageTypeString);
+  const binary = message.serializeBinary();
+  if (!validateNode) {
+    validateNode = $('.validate', node).first();
+  }
+  xhr.responseType = 'json';
+  xhr.onload = function() {
+    const validationOutput = xhr.response;
+    const errors = validationOutput.errors;
+    const warnings = validationOutput.warnings;
+    // Add client-side validation errors.
+    $(node).find('.invalid').each(function(index) {
+      const invalidName = $(this).attr('class').split(' ')[0];
+      errors.push('Value for ' + invalidName + ' is invalid');
+    });
+    const statusNode = $('.validate_status', validateNode);
+    const messageNode = $('.validate_message', validateNode);
+    statusNode.removeClass('fa-check');
+    statusNode.removeClass('fa-exclamation-triangle');
+    statusNode.css('backgroundColor', null);
+    statusNode.text('');
+    if (errors.length) {
+      statusNode.addClass('fa fa-exclamation-triangle');
+      statusNode.css('color', 'red');
+      statusNode.text(' ' + errors.length);
+      messageNode.html('<ul></ul>');
+      for (let index = 0; index < errors.length; index++) {
+        const error = errors[index];
+        const errorNode = $('<li></li>');
+        errorNode.text(error);
+        $('ul', messageNode).append(errorNode);
+      }
+      messageNode.css('backgroundColor', 'pink');
+    } else {
+      statusNode.addClass('fa fa-check');
+      statusNode.css('color', 'green');
+      messageNode.html('');
+      messageNode.css('backgroundColor', '');
+      messageNode.css('visibility', 'hidden');
+    }
+    const warningStatusNode = $('.validate_warning_status', validateNode);
+    const warningMessageNode = $('.validate_warning_message', validateNode);
+    if (warnings.length) {
+      warningStatusNode.show();
+      warningStatusNode.text(' ' + warnings.length);
+      warningMessageNode.show();
+      warningMessageNode.html('<ul></ul>');
+      for (let index = 0; index < warnings.length; index++) {
+        const warning = warnings[index];
+        const warningNode = $('<li></li>');
+        warningNode.text(warning);
+        $('ul', warningMessageNode).append(warningNode);
+      }
+    } else {
+      warningStatusNode.hide();
+      warningMessageNode.html('');
+      warningMessageNode.hide();
+    }
+  };
+  xhr.send(binary);
+}
+
+/**
+ * Toggles the visibility of the 'validate' button for a given node.
+ * @param {!Node} node
+ * @param {string} target Destination class for the validation message(s).
+ */
+function toggleValidateMessage(node, target) {
+  let messageNode = $(target, node);
+  switch (messageNode.css('visibility')) {
+    case 'visible':
+      messageNode.css('visibility', 'hidden');
+      break;
+    case 'hidden':
+      messageNode.css('visibility', 'visible');
+      break;
+  }
+}
+
+/**
+ * Updates the visual summary of the current reaction.
+ * @param {!proto.ord.Reaction} reaction
+ */
+function renderReaction(reaction) {
+  const xhr = new XMLHttpRequest();
+  xhr.open('POST', '/render/reaction');
+  const binary = reaction.serializeBinary();
+  xhr.responseType = 'json';
+  xhr.onload = function() {
+    const html_block = xhr.response;
+    $('#reaction_render').html(html_block);
+  };
+  xhr.send(binary);
+}
+
+/**
+ * Validates the current reaction.
+ */
+function validateReaction() {
+  const node = $('#sections');
+  const validateNode = $('#reaction_validate');
+  const reaction = unloadReaction();
+  validate(reaction, 'Reaction', node, validateNode);
+  // Trigger all submessages to validate.
+  $('.validate_button:visible:not(#reaction_validate_button)').trigger('click');
+  // Render reaction as an HTML block.
+  renderReaction(reaction);
+}
+
+/**
+ * Writes the current reaction to disk.
+ */
+function commit() {
+  if (!session.dataset) {
+    // Do nothing when there is no Dataset; e.g. when viewing reactions by ID.
+    return;
+  }
+  const reaction = unloadReaction();
+  const reactions = session.dataset.getReactionsList();
+  reactions[session.index] = reaction;
+  putDataset(session.fileName, session.dataset);
+  ord.uploads.putAll(session.fileName);
+}
+
+/**
+ * Downloads the current reaction as a serialized Reaction proto.
+ */
+function downloadReaction() {
+  const reaction = unloadReaction();
+  const binary = reaction.serializeBinary();
+  const xhr = new XMLHttpRequest();
+  xhr.open('POST', '/reaction/download');
+  xhr.onload = () => {
+    // Make the browser write the file.
+    const url = URL.createObjectURL(new Blob([xhr.response]));
+    const link = document.createElement('a');
+    link.href = url;
+    link.setAttribute('download', 'reaction.pbtxt');
+    document.body.appendChild(link);
+    link.click();
+  };
+  xhr.send(binary);
+}
+
+/**
+ * Downloads a dataset as a serialized Dataset proto.
+ * @param {string} fileName The name of the dataset to fetch.
+ * @return {!Promise<!Uint8Array>}
+ */
+function getDataset(fileName) {
+  return new Promise(resolve => {
+    const xhr = new XMLHttpRequest();
+    xhr.open('GET', '/dataset/proto/read/' + fileName);
+    xhr.responseType = 'arraybuffer';
+    xhr.onload = function(event) {
+      const bytes = new Uint8Array(xhr.response);
+      const dataset = proto.ord.Dataset.deserializeBinary(bytes);
+      resolve(dataset);
+    };
+    xhr.send();
+  });
+}
+
+/**
+ * Uploads a serialized Dataset proto.
+ * @param {string} fileName The name of the new dataset.
+ * @param {!proto.ord.Dataset} dataset
+ */
+function putDataset(fileName, dataset) {
+  $('#save').text('saving');
+  const xhr = new XMLHttpRequest();
+  xhr.open('POST', '/dataset/proto/write/' + fileName);
+  const binary = dataset.serializeBinary();
+  xhr.onload = clean;
+  xhr.send(binary);
+}
+
+/**
+ * Compares a local Dataset to a Dataset on the server (used for testing).
+ * @param {string} fileName The name of a dataset on the server.
+ * @param {!proto.ord.Dataset} dataset A local Dataset.
+ * @return {!Promise<!Uint8Array>}
+ */
+async function compareDataset(fileName, dataset) {
+  return new Promise((resolve, reject) => {
+    const xhr = new XMLHttpRequest();
+    xhr.open('POST', '/dataset/proto/compare/' + fileName);
+    const binary = dataset.serializeBinary();
+    xhr.onload = () => {
+      if (xhr.status == 200) {
+        resolve();
+      } else {
+        reject();
+      }
+    };
+    xhr.onerror = reject;
+    xhr.send(binary);
+  });
+}
+
+/**
+ * Adds and populates the form with the given reaction.
+ * @param {!proto.ord.Reaction} reaction
+ */
+function loadReaction(reaction) {
+  const identifiers = reaction.getIdentifiersList();
+  ord.identifiers.load(identifiers);
+  const inputs = reaction.getInputsMap();
+  // Reactions start with an input by default.
+  if (inputs.arr_.length) {
+    ord.inputs.load(inputs);
+  } else {
+    ord.inputs.add('#inputs');
+  }
+  const setup = reaction.getSetup();
+  if (setup) {
+    ord.setups.load(setup);
+  }
+  const conditions = reaction.getConditions();
+  if (conditions) {
+    ord.conditions.load(conditions);
+  }
+  const notes = reaction.getNotes();
+  if (notes) {
+    ord.notes.load(notes);
+  }
+  const observations = reaction.getObservationsList();
+  ord.observations.load(observations);
+
+  const workups = reaction.getWorkupsList();
+  ord.workups.load(workups);
+
+  const outcomes = reaction.getOutcomesList();
+  // Reactions start with an outcome by default.
+  if (outcomes.length) {
+    ord.outcomes.load(outcomes);
+  } else {
+    ord.outcomes.add();
+  }
+
+  const provenance = reaction.getProvenance();
+  if (provenance) {
+    ord.provenance.load(provenance);
+  }
+  $('#reaction_id').text(reaction.getReactionId());
+
+  // Clean up floating point entries.
+  $('.floattext').each(function(index) {
+    const node = $(this);
+    if (node.text() !== '') {
+      node.text(prepareFloat(parseFloat(node.text())));
+    }
+  });
+}
+
+/**
+ * Fetches the current reaction from the form.
+ * @return {!proto.ord.Reaction}
+ */
+function unloadReaction() {
+  const reaction = new proto.ord.Reaction();
+  const identifiers = ord.identifiers.unload();
+  reaction.setIdentifiersList(identifiers);
+
+  const inputs = reaction.getInputsMap();
+  // isEmptyMessage check occurs in inputs.unload.
+  ord.inputs.unload(inputs);
+
+  const setup = ord.setups.unload();
+  if (!isEmptyMessage(setup)) {
+    reaction.setSetup(setup);
+  }
+
+  const conditions = ord.conditions.unload();
+  if (!isEmptyMessage(conditions)) {
+    reaction.setConditions(conditions);
+  }
+
+  const notes = ord.notes.unload();
+  if (!isEmptyMessage(notes)) {
+    reaction.setNotes(notes);
+  }
+
+  const observations = ord.observations.unload();
+  reaction.setObservationsList(observations);
+
+  const workups = ord.workups.unload();
+  reaction.setWorkupsList(workups);
+
+  const outcomes = ord.outcomes.unload();
+  reaction.setOutcomesList(outcomes);
+
+  const provenance = ord.provenance.unload();
+  if (!isEmptyMessage(provenance)) {
+    reaction.setProvenance(provenance);
+  }
+
+  // Setter does nothing when passed an empty string.
+  reaction.setReactionId($('#reaction_id').text());
+  return reaction;
+}
+
+/**
+ * Checks if the argument represents an empty protobuf message (that is, the
+ * argument's nested arrays only contains null or empty values), or is null or
+ * undefined. We use this check on both primitives and arrays/messages.
+ * NOTE: Unlike other primitive types, using a setter to set a oneof string
+ * field to “” causes the message to include the field and “”, which would be
+ * unwanted. So we instead claim that empty strings are empty messages. (Hence
+ * we don’t set _any_ empty string.)
+ * NOTE: In a submessage, setting a meaningful value (e.g. optional float to 0)
+ * will result in a non-null/undefined value in the submessage array. So, if
+ * the array of a submessage only contains null and undefined vals, we can
+ * assume that the message is truly “empty” (that is, doesn’t have anything
+ * meaningful that is set) and can be omitted when constructing the surrounding
+ * message.
+ * @param {!jspb.Message} obj The object to test.
+ * @return {boolean} Whether the message is empty.
+ */
+function isEmptyMessage(obj) {
+  const empty = new obj.constructor();
+  // Compare binary encodings to cover optional fields.
+  return JSON.stringify(obj.serializeBinary()) ===
+      JSON.stringify(empty.serializeBinary());
+}
+
+/**
+ * Adds an instance of `template` to the root node.
+ * @param {string} template A jQuery selector.
+ * @param {!Node} root A jQuery object.
+ * @return {!Node} The new copy of the template.
+ */
+function addSlowly(template, root) {
+  const node = $(template).clone();
+  node.removeAttr('id');
+  $(root).append(node);
+  node.show('slow');
+  dirty();
+  listen(node);
+  $('[data-toggle=\'tooltip\']', node).tooltip();
+  return node;
+}
+
+/**
+ * Removes from the DOM the nearest ancestor element matching the pattern.
+ * @param {string} button The element from which to start the search.
+ * @param {string} pattern The pattern for the element to remove.
+ */
+function removeSlowly(button, pattern) {
+  const node = $(button).closest(pattern);
+  // Must call necessary validators only after the node is removed,
+  // but we can only figure out which validators these are before removal.
+  // We do so, and after removal, click the corresponding buttons to trigger
+  // validation.
+  let buttonsToClick = $();
+  node.parents('fieldset').each(function() {
+    buttonsToClick =
+        buttonsToClick.add($(this).children('legend').find('.validate_button'));
+  });
+  makeUndoable(node);
+  node.hide('slow', function() {
+    buttonsToClick.trigger('click');
+    ord.inputs.updateSidebar();
+  });
+  dirty();
+}
+
+/**
+ * Reverses the hide() in the most recent invocation of removeSlowly().
+ * Removes the node's "undo" button. Does not trigger validation.
+ */
+function undoSlowly() {
+  $('.undoable').removeClass('undoable').show('slow');
+  $('.undo').not('#undo_template').hide('slow', function() {
+    $(this).remove();
+    ord.inputs.updateSidebar();
+  });
+  dirty();
+}
+
+/**
+ * Marks the given node for possible future undo. Adds an "undo" button to do
+ * it. Deletes any preexisting undoable nodes and undo buttons.
+ * @param {!Node} node The DOM fragment to hide and re-show.
+ */
+function makeUndoable(node) {
+  $('.undoable').remove();
+  node.addClass('undoable');
+  $('.undo').not('#undo_template').remove();
+  const button = $('#undo_template').clone();
+  button.removeAttr('id');
+  node.after(button);
+  button.show('slow');
+}
+
+/**
+ * Supports unload() operations by filtering spurious selector matches due
+ * either to DOM templates or elements the user has removed undoably.
+ * @param {!Node node} node The DOM node to test for spuriousness.
+ * @return {boolean} True means ignore this node.
+ */
+function isTemplateOrUndoBuffer(node) {
+  return node.attr('id') || node.hasClass('undoable');
+}
+
+/**
+ * Toggles the visibility of all siblings of an element, or if a pattern is
+ * provided, toggles the visibility of all siblings of the nearest ancestor
+ * element matching the pattern.
+ * @param {!Node} node The element to toggle or use as the search root.
+ * @param {string} pattern The pattern to match for finding siblings to toggle.
+ */
+//
+function toggleSlowly(node, pattern) {
+  node = $(node);
+  if (pattern) {
+    node = node.closest(pattern);
+  }
+  // 'collapsed' tag is used to hold previously collapsed siblings,
+  // and would be stored as node's next sibling;
+  // the following line checks whether a collapse has occured.
+  if (node.next('collapsed').length !== 0) {
+    // Need to uncollapse.
+    const collapsedNode = node.next('collapsed');
+    collapsedNode.toggle('slow', () => {
+      collapsedNode.children().unwrap();
+    });
+  } else {
+    // Need to collapse.
+    node.siblings().wrapAll('<collapsed>');
+    node.next('collapsed').toggle('slow');
+  }
+}
+
+/**
+ * Toggles the collapse of a section in the form.
+ * @param {string} button The element to toggle.
+ */
+function collapseToggle(button) {
+  $(button).toggleClass('fa-chevron-down fa-chevron-right');
+  toggleSlowly(button, 'legend');
+}
+
+/**
+ * Unpacks a (value, units, precision) tuple into the given type.
+ * @param {string} prefix The prefix for element attributes.
+ * @param {!jspb.Message} proto A protocol buffer with `value`, `precision`,
+ *     and `units` fields.
+ * @param {!Node} node The node containing the tuple.
+ * @return {!jspb.Message} The updated protocol buffer. Note that the message
+ *     is modified in-place.
+ */
+function readMetric(prefix, proto, node) {
+  const value = parseFloat($(prefix + '_value', node).text());
+  if (!isNaN(value)) {
+    proto.setValue(value);
+  }
+  if (proto.setUnits) {
+    // proto.ord.Percentage doesn't have units.
+    proto.setUnits(getSelector($(prefix + '_units', node)));
+  }
+  const precision = parseFloat($(prefix + '_precision', node).text());
+  if (!isNaN(precision)) {
+    proto.setPrecision(precision);
+  }
+  return proto;
+}
+
+/**
+ * Packs a (value, units, precision) tuple into form elements.
+ * @param {string} prefix The prefix for element attributes.
+ * @param {!jspb.Message} proto A protocol buffer with `value`, `precision`,
+ *     and`units` fields.
+ * @param {!Node} node The target node for the tuple.
+ */
+function writeMetric(prefix, proto, node) {
+  if (!(proto)) {
+    return;
+  }
+  if (proto.hasValue()) {
+    $(prefix + '_value', node).text(proto.getValue());
+  }
+  if (proto.getUnits) {
+    // proto.ord.Percentage doesn't have units.
+    setSelector($(prefix + '_units', node), proto.getUnits());
+  }
+  if (proto.hasPrecision()) {
+    $(prefix + '_precision', node).text(proto.getPrecision());
+  }
+}
+
+/**
+ * Prompts the user to upload a file and sets the target node text with its
+ * contents.
+ * @param {!Node} identifierNode The node to update with the file contents.
+ * @param {string} valueClass The class containing `identifierNode`.
+ */
+function setTextFromFile(identifierNode, valueClass) {
+  const input = document.createElement('input');
+  input.type = 'file';
+  input.onchange = (event => {
+    const file = event.target.files[0];
+    const reader = new FileReader();
+    reader.readAsText(file);
+    reader.onload = readerEvent => {
+      const contents = readerEvent.target.result;
+      $('.' + valueClass, identifierNode).text(contents);
+    };
+  });
+  input.click();
+}
+
+/**
+ * Adds and populates a <select/> node according to its data-proto type
+ * declaration.
+ * @param {!Node} node A node containing a `data-proto` attribute.
+ */
+function initSelector(node) {
+  const protoName = node.attr('data-proto');
+  const protoEnum = nameToProto(protoName);
+  if (!protoEnum) {
+    console.log('missing require: "' + protoName + '"');
+  }
+  const types = Object.entries(protoEnum);
+  const select = $('<select>');
+  for (let i = 0; i < types.length; i++) {
+    const option = $('<option>').text(types[i][0]);
+    option.attr('value', types[i][1]);
+    if (types[i][0] == 'UNSPECIFIED') {
+      option.attr('selected', 'selected');
+    }
+    select.append(option);
+  }
+  node.append(select);
+}
+
+/**
+ * Selects an <option/> under a <select/>.
+ * @param {!Node} node A <select/> element.
+ * @param {number} value
+ */
+function setSelector(node, value) {
+  $('option', node).first().removeAttr('selected');
+  $('option[value=' + value + ']', node).first().attr('selected', 'selected');
+}
+
+/**
+ * Finds the selected <option/> and maps its text onto a proto Enum.
+ * @param {!Node} node A <select/> element.
+ * @return {number}
+ */
+function getSelector(node) {
+  return parseInt($('select', node).first().val());
+}
+
+/**
+ * Finds the selected <option/> and returns its text.
+ * @param {!Node} node A node containing one or more <select/> elements.
+ * @return {string}
+ */
+function getSelectorText(node) {
+  const selectorElement = node.getElementsByTagName('select')[0];
+  return selectorElement.options[selectorElement.selectedIndex].text;
+}
+
+/**
+ * Sets up a three-way popup (true/false/unspecified).
+ * @param {!Node} node Target node for the new <select/> element.
+ */
+function initOptionalBool(node) {
+  const select = $('<select>');
+  const options = ['UNSPECIFIED', 'TRUE', 'FALSE'];
+  for (let i = 0; i < options.length; i++) {
+    const option = $('<option>').text(options[i]);
+    option.attr('value', options[i]);
+    if (options[i] == 'UNSPECIFIED') {
+      option.attr('selected', 'selected');
+    }
+    select.append(option);
+  }
+  node.append(select);
+}
+
+/**
+ * Sets the value of a three-way popup (true/false/unspecified).
+ * @param {!Node} node A node containing a three-way selector.
+ * @param {boolean|null} value The value to select.
+ */
+function setOptionalBool(node, value) {
+  $('option', node).removeAttr('selected');
+  if (value == true) {
+    $('option[value=TRUE]', node).attr('selected', 'selected');
+  }
+  if (value == false) {
+    $('option[value=FALSE]', node).attr('selected', 'selected');
+  }
+  if (value == null) {
+    $('option[value=UNSPECIFIED]', node).attr('selected', 'selected');
+  }
+}
+
+/**
+ * Fetches the value of a three-way popup (true/false/unspecified).
+ * @param {!Node} node A node containing a three-way selector.
+ * @return {boolean|null}
+ */
+function getOptionalBool(node) {
+  const value = $('select', node).val();
+  if (value == 'TRUE') {
+    return true;
+  }
+  if (value == 'FALSE') {
+    return false;
+  }
+  return null;
+}
+
+/**
+ * Sets up and initializes a collapse button by adding attributes into a div in
+ * reaction.html.
+ * @param {!Node} node Target node for the new button.
+ */
+function initCollapse(node) {
+  node.addClass('fa');
+  node.addClass('fa-chevron-down');
+  node.attr('onclick', 'ord.reaction.collapseToggle(this)');
+  if (node.hasClass('starts_collapsed')) {
+    node.trigger('click');
+  }
+}
+
+/**
+ * Sets up a validator div (button, status indicator, error list, etc.) by
+ * inserting contents into a div in reaction.html.
+ * @param {!Node} oldNode Target node for the new validation elements.
+ */
+function initValidateNode(oldNode) {
+  let newNode = $('#validate_template').clone();
+  // Add attributes necessary for validation functions:
+  // Convert the placeholder onclick method into the button's onclick method.
+  $('.validate_button', newNode).attr('onclick', oldNode.attr('onclick'));
+  oldNode.removeAttr('onclick');
+  // Add an id to the button.
+  if (oldNode.attr('id')) {
+    $('.validate_button', newNode).attr('id', oldNode.attr('id') + '_button');
+  }
+  oldNode.append(newNode.children());
+}
+
+/**
+ * Initializes the validation handlers. Some nodes are dynamically added or
+ * removed; we add their validation handlers when the nodes themselves are
+ * added. However, other nodes are always present in the HTML, and aren't
+ * dynamically added nor removed. We add live validation to these nodes here.
+ */
+function initValidateHandlers() {
+  // For setup
+  const setupNode = $('#section_setup');
+  addChangeHandler(setupNode, () => {
+    ord.setups.validateSetup(setupNode);
+  });
+
+  // For conditions
+  const conditionNode = $('#section_conditions');
+  addChangeHandler(conditionNode, () => {
+    ord.conditions.validateConditions(conditionNode);
+  });
+
+  // For temperature
+  const temperatureNode = $('#section_conditions_temperature');
+  addChangeHandler(temperatureNode, () => {
+    ord.temperature.validateTemperature(temperatureNode);
+  });
+
+  // For pressure
+  const pressureNode = $('#section_conditions_pressure');
+  addChangeHandler(pressureNode, () => {
+    ord.pressure.validatePressure(pressureNode);
+  });
+
+  // For stirring
+  const stirringNode = $('#section_conditions_stirring');
+  addChangeHandler(stirringNode, () => {
+    ord.stirring.validateStirring(stirringNode);
+  });
+
+  // For illumination
+  const illuminationNode = $('#section_conditions_illumination');
+  addChangeHandler(illuminationNode, () => {
+    ord.illumination.validateIllumination(illuminationNode);
+  });
+
+  // For electro
+  const electroNode = $('#section_conditions_electro');
+  addChangeHandler(electroNode, () => {
+    ord.electro.validateElectro(electroNode);
+  });
+
+  // For flow
+  const flowNode = $('#section_conditions_flow');
+  addChangeHandler(flowNode, () => {
+    ord.flows.validateFlow(flowNode);
+  });
+
+  // For notes
+  const notesNode = $('#section_notes');
+  addChangeHandler(notesNode, () => {
+    ord.notes.validateNotes(notesNode);
+  });
+
+  // For provenance
+  const provenanceNode = $('#section_provenance');
+  addChangeHandler(provenanceNode, () => {
+    ord.provenance.validateProvenance(provenanceNode);
+  });
+}
+
+/**
+ * Converts a Message_Field name from a data-proto attribute into a proto class.
+ * @param {string} protoName Underscore-delimited protocol buffer field name,
+ *     such as Reaction_provenance.
+ * @return {?typeof jspb.Message}
+ */
+function nameToProto(protoName) {
+  let clazz = proto.ord;
+  protoName.split('_').forEach(function(name) {
+    clazz = clazz[name];
+    if (!clazz) {
+      return null;
+    }
+  });
+  return clazz;
+}
+
+/**
+ * Converts an Enum name string to its protobuf member value.
+ * @param {string} name A text representation of an enum member.
+ * @param {!enum} protoEnum The protocol buffer enum to search.
+ * @return {number}
+ */
+function stringToEnum(name, protoEnum) {
+  return protoEnum[name];
+}
+
+/**
+ * Switches the UI into a read-only mode. This is irreversible.
+ */
+function freeze() {
+  // Hide the header buttons...
+  $('#header_buttons').children().hide();
+  // ...except for "download".
+  $('#download').show();
+  $('#identity').hide();
+  $('select').attr('disabled', 'true');
+  $('input:radio').prop('disabled', 'true');
+  $('.validate').hide();
+  $('.add').hide();
+  $('.remove').hide();
+  $('.text_upload').hide();
+  $('#provenance_created button').hide();
+  $('.edittext').each((i, x) => {
+    const node = $(x);
+    node.attr('contenteditable', 'false');
+    node.css('background-color', '#ebebe4');
+  });
+}
+
+/**
+ * Highlights navigation buttons in the sidebar corresponding to visible
+ * sections. Used as a callback function for the IntersectionObserver.
+ * @param {!Array<!IntersectionObserverEntry>} entries
+ */
+function observerCallback(entries) {
+  entries.forEach(entry => {
+    const target = $(entry.target);
+    let section;
+    if (target[0].hasAttribute('input_name')) {
+      section = target.attr('input_name');
+    } else {
+      section = target.attr('id').split('_')[1];
+    }
+    if (entry.isIntersecting) {
+      session.navSelectors[section].css('background-color', 'lightblue');
+    } else {
+      session.navSelectors[section].css('background-color', '');
+    }
+  });
+}
+
+/**
+ * Sets up the IntersectionObserver used to highlight navigation buttons
+ * in the sidebar.
+ */
+function setupObserver() {
+  const headerSize = $('#header').outerHeight();
+  const observerOptions = {rootMargin: '-' + headerSize + 'px 0px 0px 0px'};
+  session.observer =
+      new IntersectionObserver(observerCallback, observerOptions);
+  updateObserver();
+}
+
+/**
+ * Updates the set of elements watched by the IntersectionObserver.
+ */
+function updateObserver() {
+  if (!session.observer) {
+    return;  // Do nothing until setupObserver has been run.
+  }
+  session.observer.disconnect();
+  $('.section:visible').not('.workup_input').each(function() {
+    session.observer.observe(this);
+  });
+  // Index the selector controls.
+  session.navSelectors = {};
+  $('.navSection').each((index, selector) => {
+    selector = $(selector);
+    const section = selector.attr('data-section');
+    session.navSelectors[section] = selector;
+  });
+  $('.inputNavSection').each((index, selector) => {
+    selector = $(selector);
+    const section = selector.attr('input_name');
+    session.navSelectors[section] = selector;
+  });
+}

--- a/js/workups.js
+++ b/js/workups.js
@@ -24,9 +24,11 @@ exports = {
   validateWorkup
 };
 
-goog.require('ord.inputs');
-goog.require('proto.ord.ReactionWorkup');
 goog.require('ord.amounts');
+goog.require('ord.inputs');
+goog.require('ord.utils');
+goog.require('proto.ord.ReactionWorkup');
+
 
 /**
  * Adds and populates the reaction workup sections in the form.
@@ -42,11 +44,11 @@ function load(workups) {
  */
 function loadWorkup(workup) {
   const node = add();
-  ord.reaction.setSelector($('.workup_type', node), workup.getType());
+  ord.utils.setSelector($('.workup_type', node), workup.getType());
   $('.workup_details', node).text(workup.getDetails());
   const duration = workup.getDuration();
   if (duration) {
-    ord.reaction.writeMetric('.workup_duration', duration, node);
+    ord.utils.writeMetric('.workup_duration', duration, node);
   }
 
   const input = workup.getInput();
@@ -61,13 +63,13 @@ function loadWorkup(workup) {
   if (temperature) {
     const control = temperature.getControl();
     if (control) {
-      ord.reaction.setSelector(
+      ord.utils.setSelector(
           $('.workup_temperature_control_type', node), control.getType());
       $('.workup_temperature_details', node).text(control.getDetails());
     }
     const setpoint = temperature.getSetpoint();
     if (setpoint) {
-      ord.reaction.writeMetric('.workup_temperature_setpoint', setpoint, node);
+      ord.utils.writeMetric('.workup_temperature_setpoint', setpoint, node);
     }
 
     temperature.getMeasurementsList().forEach(
@@ -80,13 +82,13 @@ function loadWorkup(workup) {
   if (stirring) {
     const method = stirring.getMethod();
     if (method) {
-      ord.reaction.setSelector(
+      ord.utils.setSelector(
           $('.workup_stirring_method_type', node), method.getType());
       $('.workup_stirring_method_details', node).text(method.getDetails());
     }
     const rate = stirring.getRate();
     if (rate) {
-      ord.reaction.setSelector(
+      ord.utils.setSelector(
           $('.workup_stirring_rate_type', node), rate.getType());
       $('.workup_stirring_rate_details', node).text(rate.getDetails());
       const rpm = rate.getRpm();
@@ -98,7 +100,7 @@ function loadWorkup(workup) {
   if (workup.hasTargetPh()) {
     $('.workup_target_ph', node).text(workup.getTargetPh());
   }
-  ord.reaction.setOptionalBool(
+  ord.utils.setOptionalBool(
       $('.workup_automated', node),
       workup.hasIsAutomated() ? workup.getIsAutomated() : null);
 }
@@ -111,18 +113,17 @@ function loadWorkup(workup) {
  */
 function loadMeasurement(workupNode, measurement) {
   const node = addMeasurement(workupNode);
-  ord.reaction.setSelector(
+  ord.utils.setSelector(
       $('.workup_temperature_measurement_type', node), measurement.getType());
   $('.workup_temperature_measurement_details', node)
       .text(measurement.getDetails());
   const time = measurement.getTime();
   if (time) {
-    ord.reaction.writeMetric(
-        '.workup_temperature_measurement_time', time, node);
+    ord.utils.writeMetric('.workup_temperature_measurement_time', time, node);
   }
   const temperature = measurement.getTemperature();
   if (temperature) {
-    ord.reaction.writeMetric(
+    ord.utils.writeMetric(
         '.workup_temperature_measurement_temperature', temperature, node);
   }
 }
@@ -135,9 +136,9 @@ function unload() {
   const workups = [];
   $('.workup').each(function(index, node) {
     node = $(node);
-    if (!ord.reaction.isTemplateOrUndoBuffer(node)) {
+    if (!ord.utils.isTemplateOrUndoBuffer(node)) {
       const workup = unloadWorkup(node);
-      if (!ord.reaction.isEmptyMessage(workup)) {
+      if (!ord.utils.isEmptyMessage(workup)) {
         workups.push(workup);
       }
     }
@@ -153,39 +154,39 @@ function unload() {
 function unloadWorkup(node) {
   const workup = new proto.ord.ReactionWorkup();
 
-  workup.setType(ord.reaction.getSelector($('.workup_type', node)));
+  workup.setType(ord.utils.getSelector($('.workup_type', node)));
 
   workup.setDetails($('.workup_details', node).text());
 
   const duration =
-      ord.reaction.readMetric('.workup_duration', new proto.ord.Time(), node);
-  if (!ord.reaction.isEmptyMessage(duration)) {
+      ord.utils.readMetric('.workup_duration', new proto.ord.Time(), node);
+  if (!ord.utils.isEmptyMessage(duration)) {
     workup.setDuration(duration);
   }
 
   const input = ord.inputs.unloadInputUnnamed(node);
-  if (!ord.reaction.isEmptyMessage(input)) {
+  if (!ord.utils.isEmptyMessage(input)) {
     workup.setInput(input);
   }
 
   const amount = ord.amounts.unload($('.workup_amount', node));
-  if (!ord.reaction.isEmptyMessage(amount)) {
+  if (!ord.utils.isEmptyMessage(amount)) {
     workup.setAmount(amount);
   }
 
   const control = new proto.ord.TemperatureConditions.TemperatureControl();
   control.setType(
-      ord.reaction.getSelector($('.workup_temperature_control_type', node)));
+      ord.utils.getSelector($('.workup_temperature_control_type', node)));
   control.setDetails($('.workup_temperature_details', node).text());
 
   const temperature = new proto.ord.TemperatureConditions();
-  if (!ord.reaction.isEmptyMessage(control)) {
+  if (!ord.utils.isEmptyMessage(control)) {
     temperature.setControl(control);
   }
 
-  const setpoint = ord.reaction.readMetric(
+  const setpoint = ord.utils.readMetric(
       '.workup_temperature_setpoint', new proto.ord.Temperature(), node);
-  if (!ord.reaction.isEmptyMessage(setpoint)) {
+  if (!ord.utils.isEmptyMessage(setpoint)) {
     temperature.setSetpoint(setpoint);
   }
 
@@ -196,13 +197,13 @@ function unloadWorkup(node) {
     if (!measurementNode.attr('id')) {
       // Not a template.
       const measurement = unloadMeasurement(measurementNode);
-      if (!ord.reaction.isEmptyMessage(measurement)) {
+      if (!ord.utils.isEmptyMessage(measurement)) {
         measurements.push(measurement);
       }
     }
   });
   temperature.setMeasurementsList(measurements);
-  if (!ord.reaction.isEmptyMessage(temperature)) {
+  if (!ord.utils.isEmptyMessage(temperature)) {
     workup.setTemperature(temperature);
   }
 
@@ -212,24 +213,24 @@ function unloadWorkup(node) {
 
   const method = new proto.ord.StirringConditions.StirringMethod();
   method.setType(
-      ord.reaction.getSelector($('.workup_stirring_method_type', node)));
+      ord.utils.getSelector($('.workup_stirring_method_type', node)));
   method.setDetails($('.workup_stirring_method_details').text());
-  if (!ord.reaction.isEmptyMessage(method)) {
+  if (!ord.utils.isEmptyMessage(method)) {
     stirring.setMethod(method);
   }
 
   const rate = new proto.ord.StirringConditions.StirringRate();
-  rate.setType(ord.reaction.getSelector($('.workup_stirring_rate_type', node)));
+  rate.setType(ord.utils.getSelector($('.workup_stirring_rate_type', node)));
   rate.setDetails($('.workup_stirring_rate_details').text());
   const rpm = parseFloat($('.workup_stirring_rate_rpm', node).text());
   if (!isNaN(rpm)) {
     rate.setRpm(rpm);
   }
-  if (!ord.reaction.isEmptyMessage(rate)) {
+  if (!ord.utils.isEmptyMessage(rate)) {
     stirring.setRate(rate);
   }
 
-  if (!ord.reaction.isEmptyMessage(stirring)) {
+  if (!ord.utils.isEmptyMessage(stirring)) {
     workup.setStirring(stirring);
   }
 
@@ -238,7 +239,7 @@ function unloadWorkup(node) {
     workup.setTargetPh(targetPh);
   }
   workup.setIsAutomated(
-      ord.reaction.getOptionalBool($('.workup_automated', node)));
+      ord.utils.getOptionalBool($('.workup_automated', node)));
   return workup;
 }
 
@@ -249,19 +250,19 @@ function unloadWorkup(node) {
  */
 function unloadMeasurement(node) {
   const measurement = new proto.ord.TemperatureConditions.Measurement();
-  measurement.setType(ord.reaction.getSelector(
-      $('.workup_temperature_measurement_type', node)));
+  measurement.setType(
+      ord.utils.getSelector($('.workup_temperature_measurement_type', node)));
   measurement.setDetails(
       $('.workup_temperature_measurement_details', node).text());
-  const time = ord.reaction.readMetric(
+  const time = ord.utils.readMetric(
       '.workup_temperature_measurement_time', new proto.ord.Time(), node);
-  if (!ord.reaction.isEmptyMessage(time)) {
+  if (!ord.utils.isEmptyMessage(time)) {
     measurement.setTime(time);
   }
-  const temperature = ord.reaction.readMetric(
+  const temperature = ord.utils.readMetric(
       '.workup_temperature_measurement_temperature',
       new proto.ord.Temperature(), node);
-  if (!ord.reaction.isEmptyMessage(temperature)) {
+  if (!ord.utils.isEmptyMessage(temperature)) {
     measurement.setTemperature(temperature);
   }
   return measurement;
@@ -272,7 +273,7 @@ function unloadMeasurement(node) {
  * @return {!Node} The newly added parent node for the reaction workup.
  */
 function add() {
-  const workupNode = ord.reaction.addSlowly('#workup_template', '#workups');
+  const workupNode = ord.utils.addSlowly('#workup_template', '#workups');
   const inputNode = $('.workup_input', workupNode);
   // The template for ReactionWorkup.input is taken from Reaction.inputs.
   const workupInputNode = ord.inputs.add(inputNode, ['workup_input']);
@@ -297,7 +298,7 @@ function add() {
   ord.amounts.init(workupNode);
 
   // Add live validation handling.
-  ord.reaction.addChangeHandler(workupNode, () => {
+  ord.utils.addChangeHandler(workupNode, () => {
     validateWorkup(workupNode);
   });
 
@@ -310,7 +311,7 @@ function add() {
  * @return {!Node} The node of the new measurement div.
  */
 function addMeasurement(node) {
-  return ord.reaction.addSlowly(
+  return ord.utils.addSlowly(
       '#workup_temperature_measurement_template',
       $('.workup_temperature_measurements', node));
 }
@@ -320,7 +321,7 @@ function addMeasurement(node) {
  * @param {!Node} node The div containing to the workup in the form.
  * @param {?Node} validateNode The target div for validation results.
  */
-function validateWorkup(node, validateNode) {
+function validateWorkup(node, validateNode = null) {
   const workup = unloadWorkup(node);
-  ord.reaction.validate(workup, 'ReactionWorkup', node, validateNode);
+  ord.utils.validate(workup, 'ReactionWorkup', node, validateNode);
 }

--- a/js/workups.js
+++ b/js/workups.js
@@ -319,7 +319,7 @@ function addMeasurement(node) {
 /**
  * Validates a workup as defined in the form.
  * @param {!Node} node The div containing to the workup in the form.
- * @param {?Node} validateNode The target div for validation results.
+ * @param {?Node=} validateNode The target div for validation results.
  */
 function validateWorkup(node, validateNode = null) {
   const workup = unloadWorkup(node);


### PR DESCRIPTION
Resolves #78 

* Pulls functions that are used in multiple modules (and/or are more specific to the form than the Reaction proto) into a new file: `utils.js`.
* Moves `updateSidebar` out of `inputs.js` into `utils.js`.